### PR TITLE
Claude bootstrap for #20

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ downloads/
 eggs/
 .eggs/
 lib/
+!web/lib/
 lib64/
 parts/
 sdist/

--- a/agents/claude-20.md
+++ b/agents/claude-20.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for claude on issue #20 -->

--- a/docs/MULTITENANCY.md
+++ b/docs/MULTITENANCY.md
@@ -1,0 +1,120 @@
+# Multi-Tenancy Pattern
+
+This document describes how tenant isolation is implemented in the Bukay web application.
+
+## Overview
+
+All business data belongs to a `Tenant`. Every tenant-scoped model (User, Service, Staff, BusinessHour, Client, Booking, Payment, AuditLog) carries a `tenantId` foreign key. The application enforces isolation at three layers:
+
+1. **Request-scoped resolution** — `resolveTenant` maps an incoming request to a Tenant record.
+2. **Context propagation** — `tenantContext` (AsyncLocalStorage) carries the resolved tenant through the call stack without prop-drilling.
+3. **Query guard** — the Prisma client extension `withTenantGuard` throws `TenantGuardError` at the query layer if a tenant-scoped model is queried without `tenantId` in the `where` clause.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `web/lib/tenant/resolveTenant.ts` | Extract tenant slug from subdomain or cookie; look up Tenant record |
+| `web/lib/tenant/tenantContext.ts` | AsyncLocalStorage store; `getTenantId()` helper |
+| `web/lib/tenant/prismaWithTenantGuard.ts` | Prisma `$extends` guard + `assertTenantScoped` |
+| `web/lib/db.ts` | Singleton base `PrismaClient` + default guarded export |
+
+## Tenant Resolution
+
+`resolveTenant(req, lookup)` resolves in this order:
+
+1. **Subdomain** — `acme.example.com` → slug `"acme"`.
+2. **Cookie** — `tenantSlug` cookie set after login for non-subdomain flows.
+
+The `lookup` argument is a `(slug: string) => Promise<ResolvedTenant | null>` callback so the function is testable without a real database. In production, pass a wrapper around `basePrisma.tenant.findUnique`.
+
+```ts
+import { basePrisma } from "@/lib/db";
+import { resolveTenant } from "@/lib/tenant/resolveTenant";
+
+const tenant = await resolveTenant(req, (slug) =>
+  basePrisma.tenant.findUnique({ where: { slug } })
+);
+```
+
+## Tenant Context (AsyncLocalStorage)
+
+Middleware resolves the tenant and runs the rest of the request inside `tenantContext.run(...)`:
+
+```ts
+import { tenantContext } from "@/lib/tenant/tenantContext";
+
+// In Next.js middleware or a route wrapper:
+tenantContext.run({ tenantId: tenant.id, tenantSlug: tenant.slug }, () => {
+  return next();
+});
+```
+
+Inside any downstream handler, retrieve the current tenant ID:
+
+```ts
+import { getTenantId } from "@/lib/tenant/tenantContext";
+
+const tenantId = getTenantId(); // throws if called outside a run() context
+```
+
+## Tenant Guard (Prisma Extension)
+
+The default `prisma` export from `web/lib/db.ts` is wrapped with `withTenantGuard`. Any guarded operation on a tenant-scoped model that lacks `where.tenantId` throws `TenantGuardError` immediately — before the query reaches the database.
+
+```ts
+import { prisma } from "@/lib/db";
+
+// Throws TenantGuardError — missing tenantId
+await prisma.user.findMany({ where: { email: "foo@example.com" } });
+
+// OK — tenantId present
+await prisma.user.findMany({ where: { tenantId, email: "foo@example.com" } });
+```
+
+Guarded operations: `findMany`, `findFirst`, `findFirstOrThrow`, `findUnique`, `findUniqueOrThrow`, `update`, `updateMany`, `delete`, `deleteMany`, `count`, `aggregate`, `groupBy`.
+
+`create` and `createMany` are **not** guarded via `where` — `tenantId` must be supplied in `data`, which the Prisma schema enforces at the type level.
+
+### Querying the Tenant table itself
+
+The `Tenant` model is not tenant-scoped (it is the root entity). Use `basePrisma` for tenant lookups:
+
+```ts
+import { basePrisma } from "@/lib/db";
+
+const tenant = await basePrisma.tenant.findUnique({ where: { slug } });
+```
+
+## Error Handling
+
+`TenantGuardError` extends `Error` with `name = "TenantGuardError"`. Catch it at the API boundary and return `400` or `403` as appropriate.
+
+```ts
+import { TenantGuardError } from "@/lib/tenant/prismaWithTenantGuard";
+
+try {
+  const rows = await prisma.booking.findMany({ where: { tenantId } });
+} catch (err) {
+  if (err instanceof TenantGuardError) {
+    return NextResponse.json({ error: "Tenant scope required" }, { status: 400 });
+  }
+  throw err;
+}
+```
+
+## Testing
+
+Unit tests live in `web/lib/tenant/__tests__/tenantGuard.test.ts`. Run with:
+
+```sh
+cd web && npm test
+```
+
+The tests cover:
+- `assertTenantScoped` throws for all tenant-scoped models when `tenantId` is absent.
+- `assertTenantScoped` passes when `tenantId` is present.
+- `withTenantGuard` extension throws on cross-tenant reads and passes on scoped reads.
+- `extractSubdomainSlug` correctly parses host headers.
+- `resolveTenant` resolves via subdomain and falls back to cookie.
+- `tenantContext` provides correct store inside `run()` and throws outside.

--- a/web/lib/db.ts
+++ b/web/lib/db.ts
@@ -1,0 +1,19 @@
+import { PrismaClient } from "../app/generated/prisma";
+import { withTenantGuard } from "./tenant/prismaWithTenantGuard";
+
+declare global {
+  // eslint-disable-next-line no-var
+  var _prismaBase: PrismaClient | undefined;
+}
+
+const basePrisma: PrismaClient =
+  globalThis._prismaBase ?? new PrismaClient({ log: ["error"] });
+
+if (process.env.NODE_ENV !== "production") {
+  globalThis._prismaBase = basePrisma;
+}
+
+// Default export is the guarded client for application code.
+// Import basePrisma directly only when querying tenant-root models (e.g. Tenant lookup).
+export { basePrisma };
+export const prisma = withTenantGuard(basePrisma);

--- a/web/lib/tenant/__tests__/tenantGuard.test.ts
+++ b/web/lib/tenant/__tests__/tenantGuard.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  assertTenantScoped,
+  TenantGuardError,
+  TENANT_SCOPED_MODELS,
+  withTenantGuard,
+} from "../prismaWithTenantGuard";
+import { extractSubdomainSlug, resolveTenant } from "../resolveTenant";
+import { tenantContext, getTenantId, getTenantIdOrNull } from "../tenantContext";
+
+// ---------------------------------------------------------------------------
+// assertTenantScoped
+// ---------------------------------------------------------------------------
+
+describe("assertTenantScoped", () => {
+  it("throws TenantGuardError when tenantId is absent from where", () => {
+    expect(() => assertTenantScoped("User", "findMany", { where: {} })).toThrow(
+      TenantGuardError
+    );
+  });
+
+  it("throws when where is undefined", () => {
+    expect(() => assertTenantScoped("Booking", "findMany", {})).toThrow(TenantGuardError);
+  });
+
+  it("throws for all guarded operations on tenant-scoped models", () => {
+    const ops = ["findFirst", "findFirstOrThrow", "update", "updateMany", "delete", "deleteMany"];
+    for (const op of ops) {
+      expect(() => assertTenantScoped("Client", op, { where: {} })).toThrow(TenantGuardError);
+    }
+  });
+
+  it("does NOT throw when tenantId is present in where", () => {
+    expect(() =>
+      assertTenantScoped("User", "findMany", { where: { tenantId: "tenant-abc" } })
+    ).not.toThrow();
+  });
+
+  it("does NOT throw for Tenant model (not tenant-scoped)", () => {
+    expect(() => assertTenantScoped("Tenant", "findMany", { where: {} })).not.toThrow();
+  });
+
+  it("does NOT throw for create operation (tenantId lives in data, not where)", () => {
+    expect(() => assertTenantScoped("User", "create", { where: {} })).not.toThrow();
+  });
+
+  it("covers all models listed in TENANT_SCOPED_MODELS", () => {
+    for (const model of TENANT_SCOPED_MODELS) {
+      expect(() => assertTenantScoped(model, "findMany", { where: {} })).toThrow(
+        TenantGuardError
+      );
+      expect(() =>
+        assertTenantScoped(model, "findMany", { where: { tenantId: "t1" } })
+      ).not.toThrow();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// withTenantGuard (integration via mock Prisma client)
+// ---------------------------------------------------------------------------
+
+describe("withTenantGuard", () => {
+  function makeMockPrisma() {
+    let capturedExtension: unknown = null;
+
+    const mockClient = {
+      $extends(ext: unknown) {
+        capturedExtension = ext;
+        // Return a proxy that invokes the extension's $allOperations handler
+        return {
+          async callOp(
+            model: string,
+            operation: string,
+            args: Record<string, unknown>
+          ) {
+            const handler = (
+              capturedExtension as {
+                query: {
+                  $allModels: {
+                    $allOperations: (ctx: {
+                      model: string;
+                      operation: string;
+                      args: Record<string, unknown>;
+                      query: (a: unknown) => Promise<unknown>;
+                    }) => Promise<unknown>;
+                  };
+                };
+              }
+            ).query.$allModels.$allOperations;
+
+            const query = vi.fn().mockResolvedValue([{ id: "1", tenantId: model }]);
+            return handler({ model, operation, args, query });
+          },
+        };
+      },
+    };
+
+    return mockClient;
+  }
+
+  it("throws TenantGuardError on cross-tenant read (missing tenantId)", async () => {
+    const mock = makeMockPrisma();
+    const guarded = withTenantGuard(mock) as ReturnType<typeof makeMockPrisma.$extends>;
+
+    await expect(
+      (guarded as { callOp: Function }).callOp("User", "findMany", { where: {} })
+    ).rejects.toThrow(TenantGuardError);
+  });
+
+  it("returns expected row when tenantId is correct", async () => {
+    const mock = makeMockPrisma();
+    const guarded = withTenantGuard(mock) as ReturnType<typeof makeMockPrisma.$extends>;
+
+    const result = await (guarded as { callOp: Function }).callOp("User", "findMany", {
+      where: { tenantId: "tenant-xyz" },
+    });
+    expect(result).toEqual([{ id: "1", tenantId: "User" }]);
+  });
+
+  it("passes through Tenant model queries without tenantId requirement", async () => {
+    const mock = makeMockPrisma();
+    const guarded = withTenantGuard(mock) as ReturnType<typeof makeMockPrisma.$extends>;
+
+    await expect(
+      (guarded as { callOp: Function }).callOp("Tenant", "findMany", { where: {} })
+    ).resolves.toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// extractSubdomainSlug
+// ---------------------------------------------------------------------------
+
+describe("extractSubdomainSlug", () => {
+  it("extracts subdomain from a 3-part hostname", () => {
+    expect(extractSubdomainSlug("acme.example.com")).toBe("acme");
+  });
+
+  it("strips port before splitting", () => {
+    expect(extractSubdomainSlug("acme.example.com:3000")).toBe("acme");
+  });
+
+  it("returns null for a bare 2-part domain", () => {
+    expect(extractSubdomainSlug("example.com")).toBeNull();
+  });
+
+  it("returns null for www subdomain", () => {
+    expect(extractSubdomainSlug("www.example.com")).toBeNull();
+  });
+
+  it("returns null for localhost", () => {
+    expect(extractSubdomainSlug("localhost")).toBeNull();
+  });
+
+  it("returns null for localhost with port", () => {
+    expect(extractSubdomainSlug("localhost:3000")).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveTenant
+// ---------------------------------------------------------------------------
+
+describe("resolveTenant", () => {
+  function makeReq(host: string, cookieSlug?: string) {
+    return {
+      headers: { get: (key: string) => (key === "host" ? host : null) },
+      cookies: { get: (key: string) => (key === "tenantSlug" && cookieSlug ? { value: cookieSlug } : undefined) },
+    } as unknown as import("next/server").NextRequest;
+  }
+
+  it("resolves via subdomain", async () => {
+    const tenant = { id: "t1", slug: "acme", name: "Acme Corp" };
+    const lookup = vi.fn().mockResolvedValue(tenant);
+
+    const result = await resolveTenant(makeReq("acme.example.com"), lookup);
+    expect(result).toEqual(tenant);
+    expect(lookup).toHaveBeenCalledWith("acme");
+  });
+
+  it("falls back to tenantSlug cookie when no subdomain", async () => {
+    const tenant = { id: "t2", slug: "beta", name: "Beta LLC" };
+    const lookup = vi.fn().mockResolvedValue(tenant);
+
+    const result = await resolveTenant(makeReq("example.com", "beta"), lookup);
+    expect(result).toEqual(tenant);
+    expect(lookup).toHaveBeenCalledWith("beta");
+  });
+
+  it("returns null when neither subdomain nor cookie resolves a tenant", async () => {
+    const lookup = vi.fn().mockResolvedValue(null);
+
+    const result = await resolveTenant(makeReq("example.com"), lookup);
+    expect(result).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// tenantContext (AsyncLocalStorage)
+// ---------------------------------------------------------------------------
+
+describe("tenantContext", () => {
+  it("getTenantId throws outside of a run context", () => {
+    expect(() => getTenantId()).toThrow(/No tenant context/);
+  });
+
+  it("getTenantIdOrNull returns null outside of a run context", () => {
+    expect(getTenantIdOrNull()).toBeNull();
+  });
+
+  it("getTenantId returns the tenantId inside a run context", async () => {
+    await new Promise<void>((resolve) => {
+      tenantContext.run({ tenantId: "tenant-001", tenantSlug: "demo" }, () => {
+        expect(getTenantId()).toBe("tenant-001");
+        resolve();
+      });
+    });
+  });
+
+  it("getTenantIdOrNull returns the tenantId inside a run context", async () => {
+    await new Promise<void>((resolve) => {
+      tenantContext.run({ tenantId: "tenant-002", tenantSlug: "test" }, () => {
+        expect(getTenantIdOrNull()).toBe("tenant-002");
+        resolve();
+      });
+    });
+  });
+});

--- a/web/lib/tenant/prismaWithTenantGuard.ts
+++ b/web/lib/tenant/prismaWithTenantGuard.ts
@@ -1,0 +1,85 @@
+// Prisma models that belong to a tenant and must always be queried with tenantId.
+// Model names match the Prisma schema (PascalCase) as surfaced in $allOperations.
+export const TENANT_SCOPED_MODELS = new Set([
+  "User",
+  "Service",
+  "Staff",
+  "BusinessHour",
+  "Client",
+  "Booking",
+  "Payment",
+  "AuditLog",
+]);
+
+// Operations where tenantId must appear in the `where` clause.
+// create/createMany are excluded — tenantId lives in `data` there.
+const GUARDED_OPS = new Set([
+  "findMany",
+  "findFirst",
+  "findFirstOrThrow",
+  "findUnique",
+  "findUniqueOrThrow",
+  "update",
+  "updateMany",
+  "delete",
+  "deleteMany",
+  "count",
+  "aggregate",
+  "groupBy",
+]);
+
+export class TenantGuardError extends Error {
+  constructor(model: string, operation: string) {
+    super(
+      `[TenantGuard] ${model}.${operation} blocked — tenantId missing from where clause`
+    );
+    this.name = "TenantGuardError";
+  }
+}
+
+/**
+ * Pure guard function — throws TenantGuardError when a tenant-scoped model
+ * is queried without tenantId in the where clause.
+ */
+export function assertTenantScoped(
+  model: string,
+  operation: string,
+  args: { where?: Record<string, unknown> | null }
+): void {
+  if (!TENANT_SCOPED_MODELS.has(model) || !GUARDED_OPS.has(operation)) return;
+  if (!args.where?.tenantId) {
+    throw new TenantGuardError(model, operation);
+  }
+}
+
+type PrismaClientLike = {
+  $extends: (extension: unknown) => unknown;
+};
+
+/**
+ * Wraps a Prisma client with the tenant-guard extension.
+ * Every guarded operation on a tenant-scoped model will throw TenantGuardError
+ * if tenantId is absent from the where clause.
+ */
+export function withTenantGuard<T extends PrismaClientLike>(base: T) {
+  return base.$extends({
+    query: {
+      $allModels: {
+        async $allOperations({
+          model,
+          operation,
+          args,
+          query,
+        }: {
+          model: string;
+          operation: string;
+          args: { where?: Record<string, unknown> | null };
+          query: (args: unknown) => Promise<unknown>;
+        }) {
+          assertTenantScoped(model, operation, args);
+          return query(args);
+        },
+      },
+    },
+  });
+}

--- a/web/lib/tenant/resolveTenant.ts
+++ b/web/lib/tenant/resolveTenant.ts
@@ -1,0 +1,47 @@
+import type { NextRequest } from "next/server";
+
+export interface ResolvedTenant {
+  id: string;
+  slug: string;
+  name: string;
+}
+
+export type TenantLookup = (slug: string) => Promise<ResolvedTenant | null>;
+
+/**
+ * Extracts the subdomain slug from a Host header value.
+ * Returns null for bare domains, "www", or localhost.
+ */
+export function extractSubdomainSlug(host: string): string | null {
+  const hostname = host.split(":")[0];
+  const parts = hostname.split(".");
+  if (parts.length >= 3 && parts[0] !== "www" && parts[0] !== "") {
+    return parts[0];
+  }
+  return null;
+}
+
+/**
+ * Resolves the tenant for an incoming request.
+ * Resolution order:
+ *   1. Subdomain (e.g. acme.example.com → slug "acme")
+ *   2. tenantSlug cookie (set after login for non-subdomain flows)
+ */
+export async function resolveTenant(
+  req: NextRequest,
+  lookup: TenantLookup
+): Promise<ResolvedTenant | null> {
+  const host = req.headers.get("host") ?? "";
+  const slug = extractSubdomainSlug(host);
+  if (slug) {
+    const tenant = await lookup(slug);
+    if (tenant) return tenant;
+  }
+
+  const cookieSlug = req.cookies.get("tenantSlug")?.value;
+  if (cookieSlug) {
+    return lookup(cookieSlug);
+  }
+
+  return null;
+}

--- a/web/lib/tenant/tenantContext.ts
+++ b/web/lib/tenant/tenantContext.ts
@@ -1,0 +1,22 @@
+import { AsyncLocalStorage } from "async_hooks";
+
+export interface TenantStore {
+  tenantId: string;
+  tenantSlug: string;
+}
+
+export const tenantContext = new AsyncLocalStorage<TenantStore>();
+
+export function getTenantId(): string {
+  const store = tenantContext.getStore();
+  if (!store) {
+    throw new Error(
+      "No tenant context — wrap the request handler with tenantContext.run()"
+    );
+  }
+  return store.tenantId;
+}
+
+export function getTenantIdOrNull(): string | null {
+  return tenantContext.getStore()?.tenantId ?? null;
+}


### PR DESCRIPTION
<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
Add request-scoped tenant resolution from subdomain or session. Build a Prisma client extension that rejects queries on tenant-scoped models if tenantId is missing from the where clause.

#### Tasks
- [x] Implement resolveTenant(req) helper (subdomain + session)
 - [x] Wrap Prisma client with tenant-guard extension
 - [x] Expose tenantContext via AsyncLocalStorage
 - [x] Unit tests: cross-tenant read throws; correct tenant passes
 - [x] Document pattern in docs/MULTITENANCY.md

#### Acceptance criteria
- [x] Cross-tenant query throws in test
- [x] Valid tenant query returns expected row
- [x] All existing queries updated to include tenantId
- [x] No raw prisma.*.findMany() without tenant scope

<!-- auto-status-summary:end -->

<details>

<summary>Full Issue Text</summary>



Scope
Add request-scoped tenant resolution from subdomain or session. Build a Prisma client extension that rejects queries on tenant-scoped models if tenantId is missing from the where clause.

Tasks
 - [ ] Implement resolveTenant(req) helper (subdomain + session)
 - [ ] Wrap Prisma client with tenant-guard extension
 - [ ] Expose tenantContext via AsyncLocalStorage
 - [ ] Unit tests: cross-tenant read throws; correct tenant passes
 - [ ] Document pattern in docs/MULTITENANCY.md

Acceptance Criteria
- [ ] Cross-tenant query throws in test
- [ ] Valid tenant query returns expected row
- [ ] All existing queries updated to include tenantId
- [ ] No raw prisma.*.findMany() without tenant scope



</details>

—
PR created automatically to engage Claude.

<!-- pr-preamble:start -->
> **Source:** Issue #20

<!-- pr-preamble:end -->