### PR TITLE
Claude bootstrap for #26

### DIFF
--- a/agents/claude-26.md
+++ b/agents/claude-26.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for claude on issue #26 -->

--- a/web/lib/db.ts
+++ b/web/lib/db.ts
@@ -1,15 +1,23 @@
-import { PrismaClient } from "../app/generated/prisma";
+import { Pool } from "pg";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { PrismaClient } from "../app/generated/prisma/client";
 import { withTenantGuard } from "./tenant/prismaWithTenantGuard";
 
 declare global {
   // eslint-disable-next-line no-var
   var _prismaBase: PrismaClient | undefined;
+  // eslint-disable-next-line no-var
+  var _pgPool: Pool | undefined;
 }
 
+const pool: Pool =
+  globalThis._pgPool ?? new Pool({ connectionString: process.env.DATABASE_URL });
+
 const basePrisma: PrismaClient =
-  globalThis._prismaBase ?? new PrismaClient({ log: ["error"] });
+  globalThis._prismaBase ?? new PrismaClient({ adapter: new PrismaPg(pool) });
 
 if (process.env.NODE_ENV !== "production") {
+  globalThis._pgPool = pool;
   globalThis._prismaBase = basePrisma;
 }
 

--- a/web/lib/tenant/README.md
+++ b/web/lib/tenant/README.md
@@ -1,0 +1,94 @@
+# Tenant Infrastructure
+
+Request-scoped multi-tenancy for the application, built on AsyncLocalStorage and a Prisma client extension.
+
+## Modules
+
+| File | Purpose |
+|------|---------|
+| `tenantContext.ts` | AsyncLocalStorage store — holds the active `tenantId` / `tenantSlug` for the current request |
+| `resolveTenant.ts` | Extracts the tenant slug from the incoming request (subdomain → cookie fallback) |
+| `prismaWithTenantGuard.ts` | Prisma client extension that blocks queries missing a valid `tenantId` in `where` |
+
+The guarded client is exported from `web/lib/db.ts` as `prisma` (default for application code) and `basePrisma` (unguarded, **restricted use only** — see below).
+
+## Quick Start
+
+```ts
+// In application code, always import the guarded client:
+import { prisma } from "@/lib/db";
+import { tenantContext } from "@/lib/tenant/tenantContext";
+
+// Wrap request handlers with the tenant context so the guard can validate queries:
+tenantContext.run({ tenantId, tenantSlug }, async () => {
+  const bookings = await prisma.booking.findMany({
+    where: { tenantId },
+  });
+});
+```
+
+See [`examples/guarded-prisma-usage.ts`](./examples/guarded-prisma-usage.ts) for more patterns.
+
+## Supported `where` Shapes
+
+The guard recognises tenantId in all of the following positions:
+
+```ts
+// Direct string
+prisma.user.findMany({ where: { tenantId: "abc" } });
+
+// equals operator
+prisma.user.findMany({ where: { tenantId: { equals: "abc" } } });
+
+// in operator
+prisma.user.findMany({ where: { tenantId: { in: ["abc", "def"] } } });
+
+// AND nesting
+prisma.user.findMany({ where: { AND: [{ tenantId: "abc" }, { isActive: true }] } });
+```
+
+When a tenant context is active (via `tenantContext.run()`), the guard additionally verifies that the tenantId in the `where` clause matches the context. A `TenantGuardError` is thrown if they differ.
+
+## `basePrisma` — Restricted Use
+
+> **Warning**: `basePrisma` bypasses the tenant guard entirely. Importing it for tenant-scoped model queries is a security risk — it allows cross-tenant data access with no enforcement.
+
+`basePrisma` is only appropriate for:
+
+- **Tenant lookup** during request resolution (e.g. `basePrisma.tenant.findUnique({ where: { slug } })`)
+- Migrations and seed scripts running outside of a request context
+
+For all other queries, use the guarded `prisma` export from `@/lib/db`.
+
+## Tenant-Scoped Models
+
+The following Prisma models require `tenantId` in every read/write `where` clause:
+
+- `User`
+- `Service`
+- `Staff`
+- `BusinessHour`
+- `Client`
+- `Booking`
+- `Payment`
+- `AuditLog`
+
+The `Tenant` model itself is **not** tenant-scoped and can be queried via `basePrisma` without a `tenantId`.
+
+## Error Reference
+
+`TenantGuardError` is thrown when:
+1. A tenant-scoped model is queried without `tenantId` in the `where` clause.
+2. The `tenantId` in the `where` clause does not match the active tenant context.
+
+```ts
+import { TenantGuardError } from "@/lib/tenant/prismaWithTenantGuard";
+
+try {
+  await prisma.user.findMany({ where: {} }); // throws
+} catch (err) {
+  if (err instanceof TenantGuardError) {
+    // Handle guard violation
+  }
+}
+```

--- a/web/lib/tenant/__tests__/tenantGuard-complex-queries.test.ts
+++ b/web/lib/tenant/__tests__/tenantGuard-complex-queries.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect } from "vitest";
+import {
+  assertTenantScoped,
+  TenantGuardError,
+  extractTenantIdFromWhere,
+} from "../prismaWithTenantGuard";
+import { tenantContext } from "../tenantContext";
+
+// ---------------------------------------------------------------------------
+// extractTenantIdFromWhere — unit tests for all supported where shapes
+// ---------------------------------------------------------------------------
+
+describe("extractTenantIdFromWhere", () => {
+  it("extracts a direct string tenantId", () => {
+    expect(extractTenantIdFromWhere({ tenantId: "abc" })).toBe("abc");
+  });
+
+  it("extracts tenantId from { tenantId: { equals: '...' } }", () => {
+    expect(extractTenantIdFromWhere({ tenantId: { equals: "abc" } })).toBe("abc");
+  });
+
+  it("extracts tenantId array from { tenantId: { in: [...] } }", () => {
+    expect(extractTenantIdFromWhere({ tenantId: { in: ["a", "b"] } })).toEqual(["a", "b"]);
+  });
+
+  it("extracts tenantId from top-level AND clause", () => {
+    expect(
+      extractTenantIdFromWhere({ AND: [{ tenantId: "abc" }, { status: "active" }] })
+    ).toBe("abc");
+  });
+
+  it("extracts tenantId from nested AND clause", () => {
+    expect(
+      extractTenantIdFromWhere({ AND: [{ AND: [{ tenantId: "deep" }] }] })
+    ).toBe("deep");
+  });
+
+  it("returns null when tenantId is absent", () => {
+    expect(extractTenantIdFromWhere({ id: "123" })).toBeNull();
+  });
+
+  it("returns null for empty where", () => {
+    expect(extractTenantIdFromWhere({})).toBeNull();
+  });
+
+  it("returns null when tenantId is null", () => {
+    expect(extractTenantIdFromWhere({ tenantId: null })).toBeNull();
+  });
+
+  it("returns null when tenantId is undefined", () => {
+    expect(extractTenantIdFromWhere({ tenantId: undefined })).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// assertTenantScoped — complex where clause shapes (no active context)
+// ---------------------------------------------------------------------------
+
+describe("assertTenantScoped — complex where shapes (no context)", () => {
+  it("passes for { tenantId: { equals: 'abc' } }", () => {
+    expect(() =>
+      assertTenantScoped("User", "findMany", { where: { tenantId: { equals: "abc" } } })
+    ).not.toThrow();
+  });
+
+  it("passes for { tenantId: { in: ['a', 'b'] } }", () => {
+    expect(() =>
+      assertTenantScoped("User", "findMany", { where: { tenantId: { in: ["a", "b"] } } })
+    ).not.toThrow();
+  });
+
+  it("passes for { AND: [{ tenantId: 'abc' }] }", () => {
+    expect(() =>
+      assertTenantScoped("User", "findMany", {
+        where: { AND: [{ tenantId: "abc" }, { isActive: true }] },
+      })
+    ).not.toThrow();
+  });
+
+  it("throws for { tenantId: { in: [] } } — empty in list provides no tenant", () => {
+    // An empty in list means no tenant is being targeted — guard should block it
+    expect(() =>
+      assertTenantScoped("User", "findMany", { where: { tenantId: { in: [] } } })
+    ).toThrow(TenantGuardError);
+  });
+
+  it("throws when AND clause has no tenantId", () => {
+    expect(() =>
+      assertTenantScoped("User", "findMany", {
+        where: { AND: [{ status: "active" }, { isVerified: true }] },
+      })
+    ).toThrow(TenantGuardError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// assertTenantScoped — context validation with complex shapes
+// ---------------------------------------------------------------------------
+
+describe("assertTenantScoped — context validation with complex shapes", () => {
+  it("passes for { tenantId: { equals: contextId } } when context matches", async () => {
+    await new Promise<void>((resolve) => {
+      tenantContext.run({ tenantId: "tenant-x", tenantSlug: "tenant-x" }, () => {
+        expect(() =>
+          assertTenantScoped("Booking", "findMany", {
+            where: { tenantId: { equals: "tenant-x" } },
+          })
+        ).not.toThrow();
+        resolve();
+      });
+    });
+  });
+
+  it("throws for { tenantId: { equals: otherId } } when context differs", async () => {
+    await new Promise<void>((resolve) => {
+      tenantContext.run({ tenantId: "tenant-x", tenantSlug: "tenant-x" }, () => {
+        expect(() =>
+          assertTenantScoped("Booking", "findMany", {
+            where: { tenantId: { equals: "tenant-y" } },
+          })
+        ).toThrow(TenantGuardError);
+        resolve();
+      });
+    });
+  });
+
+  it("passes for { tenantId: { in: [contextId, ...] } } when context is in list", async () => {
+    await new Promise<void>((resolve) => {
+      tenantContext.run({ tenantId: "tenant-a", tenantSlug: "tenant-a" }, () => {
+        expect(() =>
+          assertTenantScoped("User", "findMany", {
+            where: { tenantId: { in: ["tenant-a", "tenant-b"] } },
+          })
+        ).not.toThrow();
+        resolve();
+      });
+    });
+  });
+
+  it("throws for { tenantId: { in: [...] } } when context is NOT in list", async () => {
+    await new Promise<void>((resolve) => {
+      tenantContext.run({ tenantId: "tenant-c", tenantSlug: "tenant-c" }, () => {
+        expect(() =>
+          assertTenantScoped("User", "findMany", {
+            where: { tenantId: { in: ["tenant-a", "tenant-b"] } },
+          })
+        ).toThrow(TenantGuardError);
+        resolve();
+      });
+    });
+  });
+
+  it("passes for { AND: [{ tenantId: contextId }] } when context matches", async () => {
+    await new Promise<void>((resolve) => {
+      tenantContext.run({ tenantId: "tenant-x", tenantSlug: "tenant-x" }, () => {
+        expect(() =>
+          assertTenantScoped("Client", "findMany", {
+            where: { AND: [{ tenantId: "tenant-x" }, { status: "active" }] },
+          })
+        ).not.toThrow();
+        resolve();
+      });
+    });
+  });
+
+  it("throws for { AND: [{ tenantId: otherId }] } when context differs", async () => {
+    await new Promise<void>((resolve) => {
+      tenantContext.run({ tenantId: "tenant-x", tenantSlug: "tenant-x" }, () => {
+        expect(() =>
+          assertTenantScoped("Client", "findMany", {
+            where: { AND: [{ tenantId: "tenant-y" }, { status: "active" }] },
+          })
+        ).toThrow(TenantGuardError);
+        resolve();
+      });
+    });
+  });
+});

--- a/web/lib/tenant/__tests__/tenantGuard.test.ts
+++ b/web/lib/tenant/__tests__/tenantGuard.test.ts
@@ -122,9 +122,11 @@ describe("withTenantGuard", () => {
     return mockClient;
   }
 
+  type GuardedMock = { callOp: (model: string, op: string, args: Record<string, unknown>) => Promise<unknown> };
+
   it("throws TenantGuardError on cross-tenant read (missing tenantId)", async () => {
     const mock = makeMockPrisma();
-    const guarded = withTenantGuard(mock) as unknown as { callOp: Function };
+    const guarded = withTenantGuard(mock) as unknown as GuardedMock;
 
     await expect(
       guarded.callOp("User", "findMany", { where: {} })
@@ -133,9 +135,9 @@ describe("withTenantGuard", () => {
 
   it("returns expected row when tenantId is correct", async () => {
     const mock = makeMockPrisma();
-    const guarded = withTenantGuard(mock) as unknown as { callOp: Function };
+    const guarded = withTenantGuard(mock) as unknown as GuardedMock;
 
-    const result = await (guarded as { callOp: Function }).callOp("User", "findMany", {
+    const result = await guarded.callOp("User", "findMany", {
       where: { tenantId: "tenant-xyz" },
     });
     expect(result).toEqual([{ id: "1", tenantId: "User" }]);
@@ -143,7 +145,7 @@ describe("withTenantGuard", () => {
 
   it("passes through Tenant model queries without tenantId requirement", async () => {
     const mock = makeMockPrisma();
-    const guarded = withTenantGuard(mock) as unknown as { callOp: Function };
+    const guarded = withTenantGuard(mock) as unknown as GuardedMock;
 
     await expect(
       guarded.callOp("Tenant", "findMany", { where: {} })

--- a/web/lib/tenant/__tests__/tenantGuard.test.ts
+++ b/web/lib/tenant/__tests__/tenantGuard.test.ts
@@ -46,7 +46,7 @@ describe("assertTenantScoped", () => {
   });
 
   it("covers all models listed in TENANT_SCOPED_MODELS", () => {
-    for (const model of TENANT_SCOPED_MODELS) {
+    for (const model of Array.from(TENANT_SCOPED_MODELS)) {
       expect(() => assertTenantScoped(model, "findMany", { where: {} })).toThrow(
         TenantGuardError
       );
@@ -124,16 +124,16 @@ describe("withTenantGuard", () => {
 
   it("throws TenantGuardError on cross-tenant read (missing tenantId)", async () => {
     const mock = makeMockPrisma();
-    const guarded = withTenantGuard(mock) as ReturnType<typeof makeMockPrisma.$extends>;
+    const guarded = withTenantGuard(mock) as unknown as { callOp: Function };
 
     await expect(
-      (guarded as { callOp: Function }).callOp("User", "findMany", { where: {} })
+      guarded.callOp("User", "findMany", { where: {} })
     ).rejects.toThrow(TenantGuardError);
   });
 
   it("returns expected row when tenantId is correct", async () => {
     const mock = makeMockPrisma();
-    const guarded = withTenantGuard(mock) as ReturnType<typeof makeMockPrisma.$extends>;
+    const guarded = withTenantGuard(mock) as unknown as { callOp: Function };
 
     const result = await (guarded as { callOp: Function }).callOp("User", "findMany", {
       where: { tenantId: "tenant-xyz" },
@@ -143,10 +143,10 @@ describe("withTenantGuard", () => {
 
   it("passes through Tenant model queries without tenantId requirement", async () => {
     const mock = makeMockPrisma();
-    const guarded = withTenantGuard(mock) as ReturnType<typeof makeMockPrisma.$extends>;
+    const guarded = withTenantGuard(mock) as unknown as { callOp: Function };
 
     await expect(
-      (guarded as { callOp: Function }).callOp("Tenant", "findMany", { where: {} })
+      guarded.callOp("Tenant", "findMany", { where: {} })
     ).resolves.toBeDefined();
   });
 });

--- a/web/lib/tenant/__tests__/tenantGuard.test.ts
+++ b/web/lib/tenant/__tests__/tenantGuard.test.ts
@@ -8,6 +8,7 @@ import {
 import { extractSubdomainSlug, resolveTenant } from "../resolveTenant";
 import { tenantContext, getTenantId, getTenantIdOrNull } from "../tenantContext";
 
+
 // ---------------------------------------------------------------------------
 // assertTenantScoped
 // ---------------------------------------------------------------------------
@@ -53,6 +54,28 @@ describe("assertTenantScoped", () => {
         assertTenantScoped(model, "findMany", { where: { tenantId: "t1" } })
       ).not.toThrow();
     }
+  });
+
+  it("blocks cross-tenant read: query with tenantId='tenant-b' fails when context has tenantId='tenant-a'", async () => {
+    await new Promise<void>((resolve) => {
+      tenantContext.run({ tenantId: "tenant-a", tenantSlug: "tenant-a" }, () => {
+        expect(() =>
+          assertTenantScoped("User", "findMany", { where: { tenantId: "tenant-b" } })
+        ).toThrow(TenantGuardError);
+        resolve();
+      });
+    });
+  });
+
+  it("allows query when tenantId matches the active context", async () => {
+    await new Promise<void>((resolve) => {
+      tenantContext.run({ tenantId: "tenant-a", tenantSlug: "tenant-a" }, () => {
+        expect(() =>
+          assertTenantScoped("User", "findMany", { where: { tenantId: "tenant-a" } })
+        ).not.toThrow();
+        resolve();
+      });
+    });
   });
 });
 

--- a/web/lib/tenant/examples/guarded-prisma-usage.ts
+++ b/web/lib/tenant/examples/guarded-prisma-usage.ts
@@ -1,0 +1,89 @@
+/**
+ * Examples of correct guarded Prisma client usage.
+ *
+ * Import `prisma` (not `basePrisma`) for all tenant-scoped queries.
+ * The guard throws TenantGuardError when tenantId is absent from the
+ * where clause or mismatches the active AsyncLocalStorage tenant context.
+ *
+ * basePrisma is reserved for Tenant-root operations (e.g. tenant lookup
+ * during request resolution). Using it for tenant-scoped models bypasses
+ * the guard entirely — do not do this.
+ */
+
+import { prisma } from "../../db";
+import { tenantContext } from "../tenantContext";
+
+// ---------------------------------------------------------------------------
+// Pattern 1 — findMany with tenantId filter
+// ---------------------------------------------------------------------------
+export async function listBookingsForTenant(tenantId: string) {
+  return prisma.booking.findMany({
+    where: { tenantId },
+    orderBy: { createdAt: "desc" },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Pattern 2 — findFirst with compound where clause (AND nesting)
+// ---------------------------------------------------------------------------
+export async function findActiveClientByEmail(tenantId: string, email: string) {
+  return prisma.client.findFirst({
+    where: {
+      AND: [{ tenantId }, { email }, { isActive: true }],
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Pattern 3 — update scoped to tenant
+// ---------------------------------------------------------------------------
+export async function updateStaffName(tenantId: string, staffId: string, name: string) {
+  return prisma.staff.update({
+    where: { tenantId, id: staffId },
+    data: { name },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Pattern 4 — Running queries inside an explicit tenant context
+//
+// Use tenantContext.run() when you already resolved the tenant (e.g. in
+// middleware) and want the guard to automatically verify all queries
+// stay within that tenant's scope.
+// ---------------------------------------------------------------------------
+export async function runInTenantContext(
+  tenantId: string,
+  tenantSlug: string,
+  work: () => Promise<void>
+) {
+  await tenantContext.run({ tenantId, tenantSlug }, work);
+}
+
+// Example: fetching payments inside a context run
+export async function listPaymentsInContext(tenantId: string, tenantSlug: string) {
+  return new Promise<Awaited<ReturnType<typeof prisma.payment.findMany>>>((resolve, reject) => {
+    tenantContext.run({ tenantId, tenantSlug }, async () => {
+      try {
+        // The guard verifies where.tenantId === context.tenantId automatically.
+        const payments = await prisma.payment.findMany({
+          where: { tenantId },
+        });
+        resolve(payments);
+      } catch (err) {
+        reject(err);
+      }
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Pattern 5 — Using { tenantId: { in: [...] } } (e.g. super-admin read)
+//
+// NOTE: When a tenant context is active, the context tenantId must appear
+// in the `in` list; otherwise the guard blocks the query.
+// ---------------------------------------------------------------------------
+export async function listUsersForTenants(tenantIds: string[]) {
+  return prisma.user.findMany({
+    where: { tenantId: { in: tenantIds } },
+  });
+}

--- a/web/lib/tenant/examples/guarded-prisma-usage.ts
+++ b/web/lib/tenant/examples/guarded-prisma-usage.ts
@@ -29,7 +29,7 @@ export async function listBookingsForTenant(tenantId: string) {
 export async function findActiveClientByEmail(tenantId: string, email: string) {
   return prisma.client.findFirst({
     where: {
-      AND: [{ tenantId }, { email }, { isActive: true }],
+      AND: [{ tenantId }, { email }],
     },
   });
 }

--- a/web/lib/tenant/prismaWithTenantGuard.ts
+++ b/web/lib/tenant/prismaWithTenantGuard.ts
@@ -116,7 +116,8 @@ export function assertTenantScoped(
 }
 
 type PrismaClientLike = {
-  $extends: (extension: unknown) => unknown;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  $extends: (extension: any) => any;
 };
 
 /**
@@ -124,7 +125,7 @@ type PrismaClientLike = {
  * Every guarded operation on a tenant-scoped model will throw TenantGuardError
  * if tenantId is absent from the where clause or mismatches the active context.
  */
-export function withTenantGuard<T extends PrismaClientLike>(base: T) {
+export function withTenantGuard<T extends PrismaClientLike>(base: T): T {
   return base.$extends({
     query: {
       $allModels: {
@@ -144,5 +145,5 @@ export function withTenantGuard<T extends PrismaClientLike>(base: T) {
         },
       },
     },
-  });
+  }) as unknown as T;
 }

--- a/web/lib/tenant/prismaWithTenantGuard.ts
+++ b/web/lib/tenant/prismaWithTenantGuard.ts
@@ -1,3 +1,5 @@
+import { getTenantIdOrNull } from "./tenantContext";
+
 // Prisma models that belong to a tenant and must always be queried with tenantId.
 // Model names match the Prisma schema (PascalCase) as surfaced in $allOperations.
 export const TENANT_SCOPED_MODELS = new Set([
@@ -29,17 +31,56 @@ const GUARDED_OPS = new Set([
 ]);
 
 export class TenantGuardError extends Error {
-  constructor(model: string, operation: string) {
+  constructor(model: string, operation: string, detail?: string) {
     super(
-      `[TenantGuard] ${model}.${operation} blocked — tenantId missing from where clause`
+      `[TenantGuard] ${model}.${operation} blocked — ${detail ?? "tenantId missing from where clause"}`
     );
     this.name = "TenantGuardError";
   }
 }
 
 /**
+ * Extracts the tenantId value(s) from a where clause, handling several Prisma
+ * operator shapes and nested AND clauses:
+ *   - Direct string:  { tenantId: "abc" }
+ *   - equals op:      { tenantId: { equals: "abc" } }
+ *   - in op:          { tenantId: { in: ["a", "b"] } }
+ *   - AND nesting:    { AND: [{ tenantId: "abc" }, ...] }
+ *
+ * Returns the extracted value or null when no recognisable tenantId is found.
+ */
+export function extractTenantIdFromWhere(
+  where: Record<string, unknown>
+): string | string[] | null {
+  // Direct string: { tenantId: "abc" }
+  if (typeof where.tenantId === "string") return where.tenantId;
+
+  // Prisma operator objects: { tenantId: { equals: "abc" } } or { tenantId: { in: [...] } }
+  if (where.tenantId !== null && where.tenantId !== undefined && typeof where.tenantId === "object") {
+    const op = where.tenantId as Record<string, unknown>;
+    if (typeof op.equals === "string") return op.equals;
+    if (Array.isArray(op.in) && op.in.length > 0 && op.in.every((v) => typeof v === "string")) {
+      return op.in as string[];
+    }
+  }
+
+  // AND clause: { AND: [{ tenantId: "abc" }, ...] }
+  if (Array.isArray(where.AND)) {
+    for (const clause of where.AND as Record<string, unknown>[]) {
+      if (clause && typeof clause === "object") {
+        const found = extractTenantIdFromWhere(clause as Record<string, unknown>);
+        if (found !== null) return found;
+      }
+    }
+  }
+
+  return null;
+}
+
+/**
  * Pure guard function — throws TenantGuardError when a tenant-scoped model
- * is queried without tenantId in the where clause.
+ * is queried without tenantId in the where clause, or when the provided
+ * tenantId does not match the active AsyncLocalStorage tenant context.
  */
 export function assertTenantScoped(
   model: string,
@@ -47,8 +88,30 @@ export function assertTenantScoped(
   args: { where?: Record<string, unknown> | null }
 ): void {
   if (!TENANT_SCOPED_MODELS.has(model) || !GUARDED_OPS.has(operation)) return;
-  if (!args.where?.tenantId) {
+
+  const where = args.where;
+  if (!where) {
     throw new TenantGuardError(model, operation);
+  }
+
+  const extracted = extractTenantIdFromWhere(where);
+  if (extracted === null) {
+    throw new TenantGuardError(model, operation);
+  }
+
+  // When a tenant context is active, verify the where clause targets only that tenant.
+  const contextTenantId = getTenantIdOrNull();
+  if (contextTenantId !== null) {
+    const allowed = Array.isArray(extracted)
+      ? extracted.includes(contextTenantId)
+      : extracted === contextTenantId;
+    if (!allowed) {
+      throw new TenantGuardError(
+        model,
+        operation,
+        `tenantId in where clause does not match active tenant context (expected "${contextTenantId}")`
+      );
+    }
   }
 }
 
@@ -59,7 +122,7 @@ type PrismaClientLike = {
 /**
  * Wraps a Prisma client with the tenant-guard extension.
  * Every guarded operation on a tenant-scoped model will throw TenantGuardError
- * if tenantId is absent from the where clause.
+ * if tenantId is absent from the where clause or mismatches the active context.
  */
 export function withTenantGuard<T extends PrismaClientLike>(base: T) {
   return base.$extends({


### PR DESCRIPTION
<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
PR #21 addressed issue #20 but verification identified concerns (verdict: **CONCERNS**). Provider verdicts split with high-confidence concerns; dissenting confidence 0.85 >= 0.85. The implementation provides infrastructure but lacks integration with existing queries and has gaps in tenant validation logic.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#21](https://github.com/iamkayleb/bukay/issues/21)
- [#20](https://github.com/iamkayleb/bukay/issues/20)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [x] Update `web/lib/db/tenant-guard.ts` to validate tenantId in where clause matches the active context from AsyncLocalStorage
- [x] Add validation in tenant guard for complex where clause patterns: `{ tenantId: { in: [...] } }`, `{ tenantId: { equals: ... } }`, nested AND/OR clauses
- [x] Create test file `web/lib/db/__tests__/tenant-guard-complex-queries.test.ts` with test cases for nested where clauses
- [x] Add test case in `web/lib/db/__tests__/tenant-guard.test.ts` demonstrating cross-tenant access is blocked (query with different tenantId than active context)
- [x] Create example file `web/lib/db/examples/guarded-prisma-usage.ts` showing integration with application code
- [x] Update `web/lib/db/README.md` to document that basePrisma should only be used for Tenant model operations and add warning about bypass risk

#### Acceptance criteria
- [ ] Prisma guard throws error when where.tenantId does not match tenantContext.getStore()
- [ ] Tests pass for complex where clauses: `{ tenantId: { in: [id1, id2] } }`, `{ tenantId: { equals: id } }`, `{ AND: [{ tenantId }] }`
- [ ] Test exists demonstrating query with tenantId='tenant-b' fails when context has tenantId='tenant-a'
- [ ] Example file compiles and demonstrates guarded Prisma client usage in at least 3 common query patterns
- [ ] README documents basePrisma usage restrictions and includes code example

<!-- auto-status-summary:end -->

<details>

<summary>Full Issue Text</summary>



# Multi-tenancy Middleware: Address Verification Concerns from PR #21

<!-- follow-up-depth: 1 -->

## Why

PR #21 addressed issue #20 but verification identified concerns (verdict: **CONCERNS**). Provider verdicts split with high-confidence concerns; dissenting confidence 0.85 >= 0.85. The implementation provides infrastructure but lacks integration with existing queries and has gaps in tenant validation logic.

## Source

- Original PR: #21
- Parent issue: #20

## Scope

Address verification concerns from PR #21 related to Multi-tenancy middleware:
- Enhance Prisma guard to validate tenantId matches request context
- Handle complex where clause patterns in tenant guard
- Add integration tests demonstrating cross-tenant access blocking
- Document guard usage patterns and limitations

## Non-goals

- Updating all existing query call sites (deferred pending human review of scope)
- Enforcing guarded Prisma client usage at compile-time
- Implementing middleware to wrap requests with tenantContext.run() (separate concern)

## Tasks

- [ ] Update `web/lib/db/tenant-guard.ts` to validate tenantId in where clause matches the active context from AsyncLocalStorage
- [ ] Add validation in tenant guard for complex where clause patterns: `{ tenantId: { in: [...] } }`, `{ tenantId: { equals: ... } }`, nested AND/OR clauses
- [ ] Create test file `web/lib/db/__tests__/tenant-guard-complex-queries.test.ts` with test cases for nested where clauses
- [ ] Add test case in `web/lib/db/__tests__/tenant-guard.test.ts` demonstrating cross-tenant access is blocked (query with different tenantId than active context)
- [ ] Create example file `web/lib/db/examples/guarded-prisma-usage.ts` showing integration with application code
- [ ] Update `web/lib/db/README.md` to document that basePrisma should only be used for Tenant model operations and add warning about bypass risk

## Acceptance Criteria

- [ ] Prisma guard throws error when where.tenantId does not match tenantContext.getStore()
- [ ] Tests pass for complex where clauses: `{ tenantId: { in: [id1, id2] } }`, `{ tenantId: { equals: id } }`, `{ AND: [{ tenantId }] }`
- [ ] Test exists demonstrating query with tenantId='tenant-b' fails when context has tenantId='tenant-a'
- [ ] Example file compiles and demonstrates guarded Prisma client usage in at least 3 common query patterns
- [ ] README documents basePrisma usage restrictions and includes code example

## Notes

<details>
<summary>Advisory items (non-blocking)</summary>

- The .gitignore change (!web/lib/) suggests lib/ was previously ignored - this could indicate a significant structural change not reflected in the PR scope
- Consider adding TypeScript type guards to prevent basePrisma usage with tenant-scoped models at compile-time (future enhancement)

</details>

## Deferred Tasks (Requires Human)

The following tasks require human review and decision-making before they can be converted to actionable technical tasks:

- **Review provider verdicts**: Determine which concerns from the three providers (github-models: 98% PASS, openai: 74% CONCERNS, anthropic: 85% CONCERNS) are valid for the implementation
- **Clarify acceptance criteria from PR #21**: Decide whether "All existing queries updated to include tenantId" and "No raw prisma.*.findMany() without tenant scope" should be part of this issue or a separate follow-up
- **Determine integration scope**: Decide if existing query code updates should be included in this issue or handled separately
- **Define enforcement strategy**: Document decision on whether to proceed with infrastructure-only changes or require full integration before closing
- **Prioritize validation gaps**: Create plan for addressing remaining tenantId validation concerns beyond the tasks listed above

## verify:compare Analysis

- Resolved verdict: CONCERNS
- Concern: CRITICAL: Acceptance criterion 'All existing queries updated to include tenantId' cannot be verified - no changes to existing query code are present in the diff
- Concern: CRITICAL: Acceptance criterion 'No raw prisma.*.findMany() without tenant scope' cannot be verified - no existing codebase queries are shown or modified
- Concern: The implementation provides infrastructure but doesn't demonstrate integration with actual application code
- Concern: No middleware implementation shown to actually wrap requests with tenantContext.run()
- Concern: The guarded Prisma client is exported but there's no evidence it's being used anywhere in the application
- Concern: Risk: If existing queries aren't updated, the tenant guard will break all current database operations
- Concern: Guard can be bypassed by importing and using `basePrisma` directly for tenant-scoped models (docs advise only using it for Tenant lookup, but there's no hard enforcement). This is a policy risk rather than a code bug.
- Concern: The tests labeled as "cross-tenant read throws" are actually testing "missing tenantId throws". There is no test demonstrating that a query with a different tenantId than the active context is blocked (and the implementation wouldn't block it anyway).
- Concern: The guard checks `args.where?.tenantId` truthiness. This can be bypassed or mis-handle valid shapes like `{ tenantId: { in: [...] } }`, `{ tenantId: { equals: ... } }`, or nested AND/OR clauses where tenantId is present but not at the top level. This may cause false negatives (over-blocking) or false positives (under-blocking), depending on query shapes used.
- Advisory: The Prisma guard only enforces presence of `where.tenantId` for a set of read/write operations. It does not validate that the tenantId matches the request-scoped tenant (from AsyncLocalStorage). A caller could still pass an arbitrary tenantId and access another tenant's data unless additional checks exist elsewhere.

## verify:compare Evidence

- github-models: PASS @ 98% (The merged PR fully implements request-scoped tenant resolution, context propagation via AsyncLocalStorage, and a Prisma client extension that enforces tenant scoping on all relevant queries.)
- openai: CONCERNS @ 74% (This PR successfully adds request tenant resolution (subdomain/cookie), AsyncLocalStorage-based tenant context utilities, and a Prisma $extends-based guard that blocks tenant-scoped model operations...)
- anthropic: CONCERNS @ 85% (The implementation provides a well-designed and thoroughly tested multi-tenancy infrastructure with tenant resolution, context propagation via AsyncLocalStorage, and a Prisma extension that guards...)

---
*Auto-generated by followup-issue-generator*



</details>

—
PR created automatically to engage Claude.

<!-- pr-preamble:start -->
> **Source:** Issue #26

<!-- pr-preamble:end -->