### PR TITLE
chore: sync workflow templates

### DIFF
--- a/.github/agents/registry.yml
+++ b/.github/agents/registry.yml
@@ -28,6 +28,7 @@ agents:
 
   claude:
     display_name: Claude
+    model: claude-opus-4-7
     runner_workflow: .github/workflows/reusable-claude-run.yml
     required_secrets:
       - CLAUDE_CODE_OAUTH_TOKEN  # preferred: long-lived token from `claude setup-token`

--- a/.github/scripts/agent_registry.js
+++ b/.github/scripts/agent_registry.js
@@ -238,6 +238,11 @@ function getRunnerWorkflow(agentKey, { registryPath } = {}) {
   return workflow;
 }
 
+function getAgentModel(agentKey, { registryPath } = {}) {
+  const config = getAgentConfig(agentKey, { registryPath });
+  return String(config.model || '').trim();
+}
+
 /**
  * Return all automation logins across all agents in the registry.
  * Useful for detecting bot-authored comments/commits.
@@ -323,6 +328,7 @@ module.exports = {
   getAllAutomationLogins,
   getAgentConfig,
   getAgentEntries,
+  getAgentModel,
   getAgentPreflightConfigs,
   getKeepaliveMarkerPrefix,
   getReadinessCandidates,


### PR DESCRIPTION
## Sync Summary

### Files Updated
- registry.yml: Agent registry - source of truth for agent keys and runner workflow mapping
- agent_registry.js: Agent registry helper - loads registry and resolves agent key from labels

### Files Skipped
- pr-00-gate.yml: File exists and sync_mode is create_only
- ci.yml: File exists and sync_mode is create_only
- dependabot.yml: File exists and sync_mode is create_only
- llm_slots.json: None
- pyproject.toml: None

---

### Review Checklist
- [ ] CI passes with updated workflows
- [ ] No repo-specific customizations were overwritten

**Source:** stranske/Workflows
**Manifest:** `.github/sync-manifest.yml`