### PR TITLE
Codex bootstrap for #120

### DIFF
--- a/.github/workflows/agents-verify-to-issue-v2.yml
+++ b/.github/workflows/agents-verify-to-issue-v2.yml
@@ -202,6 +202,10 @@ jobs:
         id: generate
         if: steps.check-merged.outputs.merged == 'true'
         env:
+          # Repo root on PYTHONPATH so `from scripts.langchain import ...`
+          # resolves (running the script directly only puts scripts/langchain
+          # on the path, which breaks the import).
+          PYTHONPATH: ${{ github.workspace }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           CLAUDE_API_KEY: ${{ secrets.CLAUDE_API_KEY }}
           GITHUB_TOKEN: ${{ steps.select-token.outputs.token }}
@@ -232,10 +236,12 @@ jobs:
       - name: Fallback to simple extraction
         id: fallback
         # Fire not only on a hard failure but also when generation "succeeds"
-        # yet yields an empty title/body (e.g. the no-LLM path produced
-        # nothing usable). Without this the create step dies on empty output
-        # and no follow-up issue is created.
+        # yet yields an empty title/body. The leading !cancelled() supplies a
+        # status-check function so this step still evaluates after `generate`
+        # fails — without it the implicit success() gate would skip the
+        # fallback (and no follow-up issue would be created).
         if: >-
+          !cancelled() &&
           steps.check-merged.outputs.merged == 'true' &&
           (steps.generate.outcome == 'failure' ||
            steps.generate.outputs.issue_title == '' ||
@@ -322,7 +328,11 @@ jobs:
 
       - name: Create follow-up issue
         id: create-issue
-        if: steps.check-merged.outputs.merged == 'true'
+        # !cancelled() so this runs even when `generate` failed and the
+        # fallback produced the title/body.
+        if: >-
+          !cancelled() &&
+          steps.check-merged.outputs.merged == 'true'
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
         env:
           ISSUE_TITLE: >-

--- a/__tests__/app/api/settings/schedule-route.test.ts
+++ b/__tests__/app/api/settings/schedule-route.test.ts
@@ -1,0 +1,176 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type BusinessHourRow = {
+  id: string;
+  tenantId: string;
+  dayOfWeek: number;
+  opensAt: string;
+  closesAt: string;
+};
+
+type BlackoutRow = {
+  id: string;
+  tenantId: string;
+  date: string;
+  reason: string | null;
+};
+
+type NextRequestInit = NonNullable<ConstructorParameters<typeof NextRequest>[1]>;
+
+const state = vi.hoisted(() => ({
+  businessHours: [] as BusinessHourRow[],
+  blackouts: [] as BlackoutRow[],
+  businessHourFindMany: vi.fn(),
+  businessHourDeleteMany: vi.fn(),
+  businessHourCreateMany: vi.fn(),
+  blackoutFindMany: vi.fn(),
+  blackoutDeleteMany: vi.fn(),
+  blackoutCreateMany: vi.fn(),
+  transaction: vi.fn(),
+  tenantFindUnique: vi.fn(),
+}));
+
+vi.mock("@/app/db/prisma", () => ({
+  prisma: {
+    businessHour: {
+      findMany: state.businessHourFindMany,
+      deleteMany: state.businessHourDeleteMany,
+      createMany: state.businessHourCreateMany,
+    },
+    blackout: {
+      findMany: state.blackoutFindMany,
+      deleteMany: state.blackoutDeleteMany,
+      createMany: state.blackoutCreateMany,
+    },
+    tenant: {
+      findUnique: state.tenantFindUnique,
+    },
+    $transaction: state.transaction,
+  },
+}));
+
+import { GET, PUT } from "@/app/api/settings/schedule/route";
+
+function request(path: string, init: NextRequestInit = {}) {
+  return new NextRequest(`http://app.test${path}`, {
+    ...init,
+    headers: {
+      "x-tenant-id": "tenant-1",
+      ...(init.headers as Record<string, string> | undefined),
+    },
+  });
+}
+
+function jsonRequest(path: string, body: unknown, init: NextRequestInit = {}) {
+  return request(path, {
+    ...init,
+    method: init.method ?? "PUT",
+    headers: {
+      "content-type": "application/json",
+      ...(init.headers as Record<string, string> | undefined),
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  state.businessHours = [
+    { id: "hour-1", tenantId: "tenant-1", dayOfWeek: 1, opensAt: "09:00", closesAt: "12:00" },
+    { id: "hour-2", tenantId: "tenant-2", dayOfWeek: 1, opensAt: "08:00", closesAt: "16:00" },
+  ];
+  state.blackouts = [
+    { id: "blackout-1", tenantId: "tenant-1", date: "2026-12-25", reason: "Holiday" },
+  ];
+
+  state.businessHourFindMany.mockReset();
+  state.businessHourDeleteMany.mockReset();
+  state.businessHourCreateMany.mockReset();
+  state.blackoutFindMany.mockReset();
+  state.blackoutDeleteMany.mockReset();
+  state.blackoutCreateMany.mockReset();
+  state.transaction.mockReset();
+  state.tenantFindUnique.mockReset();
+
+  state.businessHourFindMany.mockImplementation(async (args: { where: { tenantId: string } }) =>
+    state.businessHours.filter((hour) => hour.tenantId === args.where.tenantId)
+  );
+  state.blackoutFindMany.mockImplementation(async (args: { where: { tenantId: string } }) =>
+    state.blackouts.filter((blackout) => blackout.tenantId === args.where.tenantId)
+  );
+  state.businessHourDeleteMany.mockResolvedValue({ count: 1 });
+  state.blackoutDeleteMany.mockResolvedValue({ count: 1 });
+  state.businessHourCreateMany.mockResolvedValue({ count: 0 });
+  state.blackoutCreateMany.mockResolvedValue({ count: 0 });
+  state.transaction.mockImplementation(async (operations: Promise<unknown>[]) =>
+    Promise.all(operations)
+  );
+});
+
+describe("/api/settings/schedule", () => {
+  it("lists tenant business hours and blackouts", async () => {
+    const res = await GET(request("/api/settings/schedule"));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.businessHours).toEqual([
+      {
+        id: "hour-1",
+        tenantId: "tenant-1",
+        dayOfWeek: 1,
+        opensAt: "09:00",
+        closesAt: "12:00",
+      },
+    ]);
+    expect(body.blackouts).toEqual([
+      {
+        id: "blackout-1",
+        tenantId: "tenant-1",
+        date: "2026-12-25",
+        reason: "Holiday",
+      },
+    ]);
+  });
+
+  it("replaces the tenant schedule with weekly windows and blackouts", async () => {
+    const res = await PUT(
+      jsonRequest("/api/settings/schedule", {
+        businessHours: [
+          { dayOfWeek: 2, opensAt: "10:00", closesAt: "16:00" },
+          { dayOfWeek: 1, opensAt: "14:00", closesAt: "18:00" },
+          { dayOfWeek: 1, opensAt: "09:00", closesAt: "12:00" },
+        ],
+        blackouts: [{ date: "2026-12-25", reason: " Christmas " }],
+      })
+    );
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toEqual({ ok: true });
+    expect(state.businessHourDeleteMany).toHaveBeenCalledWith({ where: { tenantId: "tenant-1" } });
+    expect(state.blackoutDeleteMany).toHaveBeenCalledWith({ where: { tenantId: "tenant-1" } });
+    expect(state.businessHourCreateMany).toHaveBeenCalledWith({
+      data: [
+        { tenantId: "tenant-1", dayOfWeek: 1, opensAt: "09:00", closesAt: "12:00" },
+        { tenantId: "tenant-1", dayOfWeek: 1, opensAt: "14:00", closesAt: "18:00" },
+        { tenantId: "tenant-1", dayOfWeek: 2, opensAt: "10:00", closesAt: "16:00" },
+      ],
+    });
+    expect(state.blackoutCreateMany).toHaveBeenCalledWith({
+      data: [{ tenantId: "tenant-1", date: "2026-12-25", reason: "Christmas" }],
+    });
+  });
+
+  it("rejects invalid windows before writing", async () => {
+    const res = await PUT(
+      jsonRequest("/api/settings/schedule", {
+        businessHours: [{ dayOfWeek: 1, opensAt: "18:00", closesAt: "09:00" }],
+        blackouts: [],
+      })
+    );
+
+    expect(res.status).toBe(422);
+    const body = await res.json();
+    expect(body.error).toBe("validation_failed");
+    expect(state.businessHourDeleteMany).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/app/lib/availability/engine.test.ts
+++ b/__tests__/app/lib/availability/engine.test.ts
@@ -6,6 +6,8 @@ const calls = vi.hoisted(() => ({
 
 vi.mock("@/app/lib/availability/open-windows", () => ({
   getOpenWindows: calls.getOpenWindows,
+  toTenantLocalDate: (value: Date | string) =>
+    typeof value === "string" ? value : value.toISOString().slice(0, 10),
 }));
 
 import { getAvailabilityWindows } from "@/app/lib/availability/engine";
@@ -33,5 +35,16 @@ describe("getAvailabilityWindows", () => {
     await expect(
       getAvailabilityWindows({ tenantId: "tenant-1", date: "2026-12-25" })
     ).resolves.toEqual([]);
+  });
+
+  it("normalizes Date inputs through the availability helper", async () => {
+    const date = new Date("2026-07-06T23:45:00.000Z");
+    calls.getOpenWindows.mockResolvedValue([{ opensAt: "16:00", closesAt: "18:00" }]);
+
+    await expect(getAvailabilityWindows({ tenantId: "tenant-1", date })).resolves.toEqual([
+      { date: "2026-07-06", opensAt: "16:00", closesAt: "18:00" },
+    ]);
+
+    expect(calls.getOpenWindows).toHaveBeenCalledWith("tenant-1", date);
   });
 });

--- a/__tests__/app/lib/availability/engine.test.ts
+++ b/__tests__/app/lib/availability/engine.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it, vi } from "vitest";
+
+const calls = vi.hoisted(() => ({
+  getOpenWindows: vi.fn(),
+}));
+
+vi.mock("@/app/lib/availability/open-windows", () => ({
+  getOpenWindows: calls.getOpenWindows,
+}));
+
+import { getAvailabilityWindows } from "@/app/lib/availability/engine";
+
+describe("getAvailabilityWindows", () => {
+  it("uses getOpenWindows to load availability for the requested tenant date", async () => {
+    calls.getOpenWindows.mockResolvedValue([
+      { opensAt: "09:00", closesAt: "12:00" },
+      { opensAt: "14:00", closesAt: "17:00" },
+    ]);
+
+    await expect(
+      getAvailabilityWindows({ tenantId: "tenant-1", date: "2026-07-06" })
+    ).resolves.toEqual([
+      { date: "2026-07-06", opensAt: "09:00", closesAt: "12:00" },
+      { date: "2026-07-06", opensAt: "14:00", closesAt: "17:00" },
+    ]);
+
+    expect(calls.getOpenWindows).toHaveBeenCalledWith("tenant-1", "2026-07-06");
+  });
+
+  it("returns no availability when getOpenWindows reports a blackout", async () => {
+    calls.getOpenWindows.mockResolvedValue([]);
+
+    await expect(
+      getAvailabilityWindows({ tenantId: "tenant-1", date: "2026-12-25" })
+    ).resolves.toEqual([]);
+  });
+});

--- a/__tests__/app/lib/availability/open-windows.test.ts
+++ b/__tests__/app/lib/availability/open-windows.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const state = vi.hoisted(() => ({
+  businessHours: [] as Array<{
+    tenantId: string;
+    dayOfWeek: number;
+    opensAt: string;
+    closesAt: string;
+  }>,
+  blackouts: [] as Array<{ id: string; tenantId: string; date: string }>,
+  businessHourFindMany: vi.fn(),
+  blackoutFindFirst: vi.fn(),
+}));
+
+vi.mock("@/app/db/prisma", () => ({
+  prisma: {
+    businessHour: {
+      findMany: state.businessHourFindMany,
+    },
+    blackout: {
+      findFirst: state.blackoutFindFirst,
+    },
+  },
+}));
+
+import {
+  dayOfWeekForLocalDate,
+  getOpenWindows,
+  toTenantLocalDate,
+} from "@/app/lib/availability/open-windows";
+
+beforeEach(() => {
+  state.businessHours = [];
+  state.blackouts = [];
+  state.businessHourFindMany.mockReset();
+  state.blackoutFindFirst.mockReset();
+
+  state.blackoutFindFirst.mockImplementation(
+    async (args: { where: { tenantId: string; date: string } }) =>
+      state.blackouts.find(
+        (blackout) => blackout.tenantId === args.where.tenantId && blackout.date === args.where.date
+      ) ?? null
+  );
+  state.businessHourFindMany.mockImplementation(
+    async (args: { where: { tenantId: string; dayOfWeek: number } }) =>
+      state.businessHours
+        .filter(
+          (hour) => hour.tenantId === args.where.tenantId && hour.dayOfWeek === args.where.dayOfWeek
+        )
+        .sort((left, right) => left.opensAt.localeCompare(right.opensAt))
+  );
+});
+
+describe("getOpenWindows", () => {
+  it("returns multiple sorted windows for the tenant weekday", async () => {
+    state.businessHours = [
+      { tenantId: "tenant-1", dayOfWeek: 1, opensAt: "14:00", closesAt: "18:00" },
+      { tenantId: "tenant-1", dayOfWeek: 1, opensAt: "09:00", closesAt: "12:00" },
+      { tenantId: "tenant-2", dayOfWeek: 1, opensAt: "08:00", closesAt: "16:00" },
+      { tenantId: "tenant-1", dayOfWeek: 2, opensAt: "10:00", closesAt: "15:00" },
+    ];
+
+    await expect(getOpenWindows("tenant-1", "2026-07-06")).resolves.toEqual([
+      { opensAt: "09:00", closesAt: "12:00" },
+      { opensAt: "14:00", closesAt: "18:00" },
+    ]);
+    expect(state.businessHourFindMany).toHaveBeenCalledWith({
+      where: { tenantId: "tenant-1", dayOfWeek: 1 },
+      orderBy: [{ opensAt: "asc" }, { closesAt: "asc" }],
+      select: { opensAt: true, closesAt: true },
+    });
+  });
+
+  it("returns no windows when the date is blacked out", async () => {
+    state.businessHours = [
+      { tenantId: "tenant-1", dayOfWeek: 5, opensAt: "09:00", closesAt: "18:00" },
+    ];
+    state.blackouts = [{ id: "blackout-1", tenantId: "tenant-1", date: "2026-07-10" }];
+
+    await expect(getOpenWindows("tenant-1", "2026-07-10")).resolves.toEqual([]);
+    expect(state.businessHourFindMany).not.toHaveBeenCalled();
+  });
+
+  it("normalizes dates without timezone drift for DST-free local dates", () => {
+    expect(toTenantLocalDate("2026-12-25")).toBe("2026-12-25");
+    expect(dayOfWeekForLocalDate("2026-12-25")).toBe(5);
+  });
+
+  it("rejects malformed dates and blank tenant ids", async () => {
+    expect(() => toTenantLocalDate("25-12-2026")).toThrow("YYYY-MM-DD");
+    await expect(getOpenWindows(" ", "2026-07-06")).rejects.toThrow("tenantId is required");
+  });
+});

--- a/agents/codex-120.md
+++ b/agents/codex-120.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for codex on issue #120 -->

--- a/app/(app)/settings/page.tsx
+++ b/app/(app)/settings/page.tsx
@@ -1,11 +1,5 @@
-import { SectionPlaceholder } from "../components/section-placeholder";
+import { ScheduleSettings } from "./schedule-settings";
 
 export default function SettingsPage() {
-  return (
-    <SectionPlaceholder
-      description="Manage tenant preferences, business hours, branding, and integrations."
-      hint="Settings configuration is not available yet."
-      title="Settings"
-    />
-  );
+  return <ScheduleSettings />;
 }

--- a/app/(app)/settings/schedule-settings.tsx
+++ b/app/(app)/settings/schedule-settings.tsx
@@ -1,0 +1,289 @@
+"use client";
+
+import { FormEvent, useEffect, useMemo, useState } from "react";
+
+type BusinessHour = {
+  dayOfWeek: number;
+  opensAt: string;
+  closesAt: string;
+};
+
+type Blackout = {
+  date: string;
+  reason: string;
+};
+
+type ScheduleResponse = {
+  ok: boolean;
+  error?: string;
+  businessHours?: BusinessHour[];
+  blackouts?: Blackout[];
+};
+
+const weekdays = [
+  { value: 0, label: "Sunday" },
+  { value: 1, label: "Monday" },
+  { value: 2, label: "Tuesday" },
+  { value: 3, label: "Wednesday" },
+  { value: 4, label: "Thursday" },
+  { value: 5, label: "Friday" },
+  { value: 6, label: "Saturday" },
+];
+
+const defaultBusinessHours: BusinessHour[] = [
+  { dayOfWeek: 1, opensAt: "09:00", closesAt: "18:00" },
+  { dayOfWeek: 2, opensAt: "09:00", closesAt: "18:00" },
+  { dayOfWeek: 3, opensAt: "09:00", closesAt: "18:00" },
+  { dayOfWeek: 4, opensAt: "09:00", closesAt: "18:00" },
+  { dayOfWeek: 5, opensAt: "09:00", closesAt: "18:00" },
+];
+
+function emptyBlackout(): Blackout {
+  return { date: "", reason: "" };
+}
+
+export function ScheduleSettings() {
+  const [businessHours, setBusinessHours] = useState<BusinessHour[]>(defaultBusinessHours);
+  const [blackouts, setBlackouts] = useState<Blackout[]>([]);
+  const [notice, setNotice] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isSaving, setIsSaving] = useState(false);
+
+  async function loadSchedule() {
+    setIsLoading(true);
+    setNotice(null);
+
+    try {
+      const response = await fetch("/api/settings/schedule", {
+        headers: { Accept: "application/json" },
+      });
+      const data = (await response.json()) as ScheduleResponse;
+
+      if (!response.ok || !data.ok) {
+        throw new Error(data.error ?? "Unable to load schedule");
+      }
+
+      setBusinessHours(data.businessHours ?? []);
+      setBlackouts(data.blackouts ?? []);
+    } catch (error) {
+      setNotice(error instanceof Error ? error.message : "Unable to load schedule");
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    void loadSchedule();
+  }, []);
+
+  const groupedHours = useMemo(
+    () =>
+      weekdays.map((day) => ({
+        ...day,
+        windows: businessHours.filter((hour) => hour.dayOfWeek === day.value),
+      })),
+    [businessHours]
+  );
+
+  function addWindow(dayOfWeek: number) {
+    setBusinessHours((current) => [...current, { dayOfWeek, opensAt: "09:00", closesAt: "17:00" }]);
+  }
+
+  function updateWindow(index: number, patch: Partial<BusinessHour>) {
+    setBusinessHours((current) =>
+      current.map((hour, currentIndex) => (currentIndex === index ? { ...hour, ...patch } : hour))
+    );
+  }
+
+  function removeWindow(index: number) {
+    setBusinessHours((current) => current.filter((_, currentIndex) => currentIndex !== index));
+  }
+
+  function updateBlackout(index: number, patch: Partial<Blackout>) {
+    setBlackouts((current) =>
+      current.map((blackout, currentIndex) =>
+        currentIndex === index ? { ...blackout, ...patch } : blackout
+      )
+    );
+  }
+
+  async function saveSchedule(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setIsSaving(true);
+    setNotice(null);
+
+    try {
+      const response = await fetch("/api/settings/schedule", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json", Accept: "application/json" },
+        body: JSON.stringify({
+          businessHours,
+          blackouts: blackouts.filter((blackout) => blackout.date.trim()),
+        }),
+      });
+      const data = (await response.json()) as ScheduleResponse;
+
+      if (!response.ok || !data.ok) {
+        throw new Error(data.error ?? "Unable to save schedule");
+      }
+
+      await loadSchedule();
+      setNotice("Schedule saved.");
+    } catch (error) {
+      setNotice(error instanceof Error ? error.message : "Unable to save schedule");
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  return (
+    <main className="min-h-screen bg-slate-950 px-4 py-8 text-slate-100 sm:px-6 lg:px-8">
+      <form className="mx-auto max-w-6xl space-y-6" onSubmit={(event) => void saveSchedule(event)}>
+        <div className="flex flex-col justify-between gap-3 sm:flex-row sm:items-end">
+          <div>
+            <p className="text-sm font-medium uppercase tracking-[0.18em] text-emerald-300">
+              Settings
+            </p>
+            <h1 className="mt-2 text-3xl font-semibold text-white">Business schedule</h1>
+          </div>
+          <button
+            className="rounded-md bg-emerald-500 px-4 py-2 text-sm font-semibold text-slate-950 hover:bg-emerald-400 disabled:cursor-not-allowed disabled:opacity-60"
+            disabled={isSaving || isLoading}
+            type="submit"
+          >
+            {isSaving ? "Saving..." : "Save schedule"}
+          </button>
+        </div>
+
+        {notice ? (
+          <p className="rounded-md border border-slate-800 bg-slate-900 px-4 py-3 text-sm text-slate-200">
+            {notice}
+          </p>
+        ) : null}
+
+        <section className="grid gap-6 lg:grid-cols-[minmax(0,1fr)_360px]">
+          <div className="space-y-4">
+            {groupedHours.map((day) => (
+              <div
+                className="rounded-lg border border-slate-800 bg-slate-900/60 p-4"
+                key={day.value}
+              >
+                <div className="flex items-center justify-between gap-3">
+                  <h2 className="text-base font-semibold text-white">{day.label}</h2>
+                  <button
+                    className="rounded-md border border-slate-700 px-3 py-1.5 text-xs font-medium text-slate-100 hover:border-emerald-400"
+                    type="button"
+                    onClick={() => addWindow(day.value)}
+                  >
+                    Add window
+                  </button>
+                </div>
+
+                {day.windows.length === 0 ? (
+                  <p className="mt-3 text-sm text-slate-500">Closed</p>
+                ) : (
+                  <div className="mt-3 space-y-3">
+                    {businessHours.map((hour, index) =>
+                      hour.dayOfWeek === day.value ? (
+                        <div
+                          className="grid grid-cols-[1fr_1fr_auto] items-end gap-3"
+                          key={`${hour.dayOfWeek}-${index}`}
+                        >
+                          <label className="block">
+                            <span className="text-xs font-medium text-slate-400">Opens</span>
+                            <input
+                              className="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-white outline-none focus:border-emerald-400"
+                              required
+                              type="time"
+                              value={hour.opensAt}
+                              onChange={(event) =>
+                                updateWindow(index, { opensAt: event.target.value })
+                              }
+                            />
+                          </label>
+                          <label className="block">
+                            <span className="text-xs font-medium text-slate-400">Closes</span>
+                            <input
+                              className="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-white outline-none focus:border-emerald-400"
+                              required
+                              type="time"
+                              value={hour.closesAt}
+                              onChange={(event) =>
+                                updateWindow(index, { closesAt: event.target.value })
+                              }
+                            />
+                          </label>
+                          <button
+                            className="rounded-md border border-slate-700 px-3 py-2 text-xs font-medium text-slate-100 hover:border-red-400"
+                            type="button"
+                            onClick={() => removeWindow(index)}
+                          >
+                            Remove
+                          </button>
+                        </div>
+                      ) : null
+                    )}
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+
+          <aside className="h-fit rounded-lg border border-slate-800 bg-slate-900 p-5">
+            <div className="flex items-center justify-between gap-3">
+              <h2 className="text-lg font-semibold text-white">Blackout dates</h2>
+              <button
+                className="rounded-md border border-slate-700 px-3 py-1.5 text-xs font-medium text-slate-100 hover:border-emerald-400"
+                type="button"
+                onClick={() => setBlackouts((current) => [...current, emptyBlackout()])}
+              >
+                Add date
+              </button>
+            </div>
+
+            {blackouts.length === 0 ? (
+              <p className="mt-4 text-sm text-slate-500">No closures added.</p>
+            ) : (
+              <div className="mt-4 space-y-4">
+                {blackouts.map((blackout, index) => (
+                  <div className="space-y-3 rounded-md border border-slate-800 p-3" key={index}>
+                    <label className="block">
+                      <span className="text-xs font-medium text-slate-400">Date</span>
+                      <input
+                        className="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-white outline-none focus:border-emerald-400"
+                        required
+                        type="date"
+                        value={blackout.date}
+                        onChange={(event) => updateBlackout(index, { date: event.target.value })}
+                      />
+                    </label>
+                    <label className="block">
+                      <span className="text-xs font-medium text-slate-400">Reason</span>
+                      <input
+                        className="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-white outline-none focus:border-emerald-400"
+                        maxLength={120}
+                        value={blackout.reason}
+                        onChange={(event) => updateBlackout(index, { reason: event.target.value })}
+                      />
+                    </label>
+                    <button
+                      className="rounded-md border border-slate-700 px-3 py-1.5 text-xs font-medium text-slate-100 hover:border-red-400"
+                      type="button"
+                      onClick={() =>
+                        setBlackouts((current) =>
+                          current.filter((_, currentIndex) => currentIndex !== index)
+                        )
+                      }
+                    >
+                      Remove blackout
+                    </button>
+                  </div>
+                ))}
+              </div>
+            )}
+          </aside>
+        </section>
+      </form>
+    </main>
+  );
+}

--- a/app/api/settings/schedule/route.ts
+++ b/app/api/settings/schedule/route.ts
@@ -1,0 +1,126 @@
+import { NextRequest, NextResponse } from "next/server";
+
+import { prisma } from "@/app/db/prisma";
+import { normalizeScheduleInput, updateScheduleSchema } from "@/app/lib/schedule/schemas";
+import { readJson, runForTenant, validationError } from "@/app/api/services/_helpers";
+
+export const dynamic = "force-dynamic";
+
+type BusinessHourRecord = {
+  id: string;
+  tenantId: string;
+  dayOfWeek: number;
+  opensAt: string;
+  closesAt: string;
+};
+
+type BlackoutRecord = {
+  id: string;
+  tenantId: string;
+  date: string;
+  reason: string | null;
+};
+
+const scheduleDb = prisma as unknown as {
+  businessHour: {
+    findMany(args: unknown): Promise<BusinessHourRecord[]>;
+    deleteMany(args: unknown): Promise<unknown>;
+    createMany(args: unknown): Promise<unknown>;
+  };
+  blackout: {
+    findMany(args: unknown): Promise<BlackoutRecord[]>;
+    deleteMany(args: unknown): Promise<unknown>;
+    createMany(args: unknown): Promise<unknown>;
+  };
+  $transaction<T>(operations: Promise<T>[]): Promise<T[]>;
+};
+
+function serializeBusinessHour(hour: BusinessHourRecord) {
+  return {
+    id: hour.id,
+    tenantId: hour.tenantId,
+    dayOfWeek: hour.dayOfWeek,
+    opensAt: hour.opensAt,
+    closesAt: hour.closesAt,
+  };
+}
+
+function serializeBlackout(blackout: BlackoutRecord) {
+  return {
+    id: blackout.id,
+    tenantId: blackout.tenantId,
+    date: blackout.date,
+    reason: blackout.reason ?? "",
+  };
+}
+
+export async function GET(req: NextRequest) {
+  return runForTenant(req, async (tenantId) => {
+    const [businessHours, blackouts] = await Promise.all([
+      scheduleDb.businessHour.findMany({
+        where: { tenantId },
+        orderBy: [{ dayOfWeek: "asc" }, { opensAt: "asc" }],
+      }),
+      scheduleDb.blackout.findMany({
+        where: { tenantId },
+        orderBy: [{ date: "asc" }],
+      }),
+    ]);
+
+    return NextResponse.json({
+      ok: true,
+      businessHours: businessHours.map(serializeBusinessHour),
+      blackouts: blackouts.map(serializeBlackout),
+    });
+  });
+}
+
+export async function PUT(req: NextRequest) {
+  const body = await readJson(req);
+  if (body instanceof NextResponse) {
+    return body;
+  }
+
+  const parsed = updateScheduleSchema.safeParse(body);
+  if (!parsed.success) {
+    return validationError(parsed.error);
+  }
+
+  const schedule = normalizeScheduleInput(parsed.data);
+
+  return runForTenant(req, async (tenantId) => {
+    const operations = [
+      scheduleDb.businessHour.deleteMany({ where: { tenantId } }),
+      scheduleDb.blackout.deleteMany({ where: { tenantId } }),
+    ];
+
+    if (schedule.businessHours.length > 0) {
+      operations.push(
+        scheduleDb.businessHour.createMany({
+          data: schedule.businessHours.map((hour) => ({
+            tenantId,
+            dayOfWeek: hour.dayOfWeek,
+            opensAt: hour.opensAt,
+            closesAt: hour.closesAt,
+          })),
+        })
+      );
+    }
+
+    if (schedule.blackouts.length > 0) {
+      operations.push(
+        scheduleDb.blackout.createMany({
+          data: schedule.blackouts.map((blackout) => ({
+            tenantId,
+            date: blackout.date,
+            reason: blackout.reason.trim() || null,
+          })),
+        })
+      );
+    }
+
+    await scheduleDb.$transaction(operations);
+
+    return NextResponse.json({ ok: true });
+  });
+}

--- a/app/db/tenant-guard.ts
+++ b/app/db/tenant-guard.ts
@@ -3,6 +3,7 @@ import { tenantContext } from "@/app/tenancy/tenant-context";
 
 const TENANT_SCOPED_MODELS = new Set([
   "AuditLog",
+  "Blackout",
   "Booking",
   "BusinessHour",
   "Client",

--- a/app/lib/availability/engine.ts
+++ b/app/lib/availability/engine.ts
@@ -1,0 +1,24 @@
+import { getOpenWindows, type OpenWindow } from "@/app/lib/availability/open-windows";
+
+export type AvailabilityWindow = OpenWindow & {
+  date: string;
+};
+
+export type AvailabilityEngineOptions = {
+  tenantId: string;
+  date: Date | string;
+};
+
+export async function getAvailabilityWindows({
+  tenantId,
+  date,
+}: AvailabilityEngineOptions): Promise<AvailabilityWindow[]> {
+  const windows = await getOpenWindows(tenantId, date);
+  const localDate = typeof date === "string" ? date : date.toISOString().slice(0, 10);
+
+  return windows.map((window) => ({
+    date: localDate,
+    opensAt: window.opensAt,
+    closesAt: window.closesAt,
+  }));
+}

--- a/app/lib/availability/engine.ts
+++ b/app/lib/availability/engine.ts
@@ -1,4 +1,8 @@
-import { getOpenWindows, type OpenWindow } from "@/app/lib/availability/open-windows";
+import {
+  getOpenWindows,
+  toTenantLocalDate,
+  type OpenWindow,
+} from "@/app/lib/availability/open-windows";
 
 export type AvailabilityWindow = OpenWindow & {
   date: string;
@@ -14,7 +18,7 @@ export async function getAvailabilityWindows({
   date,
 }: AvailabilityEngineOptions): Promise<AvailabilityWindow[]> {
   const windows = await getOpenWindows(tenantId, date);
-  const localDate = typeof date === "string" ? date : date.toISOString().slice(0, 10);
+  const localDate = toTenantLocalDate(date);
 
   return windows.map((window) => ({
     date: localDate,

--- a/app/lib/availability/open-windows.ts
+++ b/app/lib/availability/open-windows.ts
@@ -1,0 +1,96 @@
+import { prisma } from "@/app/db/prisma";
+
+export type OpenWindow = {
+  opensAt: string;
+  closesAt: string;
+};
+
+type BusinessHourRecord = {
+  opensAt: string;
+  closesAt: string;
+};
+
+type BlackoutRecord = {
+  id: string;
+};
+
+type AvailabilityPrisma = {
+  businessHour: {
+    findMany(args: unknown): Promise<BusinessHourRecord[]>;
+  };
+  blackout: {
+    findFirst(args: unknown): Promise<BlackoutRecord | null>;
+  };
+};
+
+const LOCAL_DATE_PATTERN = /^\d{4}-\d{2}-\d{2}$/;
+const WALL_CLOCK_PATTERN = /^([01]\d|2[0-3]):[0-5]\d$/;
+
+export function toTenantLocalDate(value: Date | string): string {
+  if (typeof value === "string") {
+    if (!LOCAL_DATE_PATTERN.test(value)) {
+      throw new Error("date must use YYYY-MM-DD format");
+    }
+
+    return value;
+  }
+
+  return value.toISOString().slice(0, 10);
+}
+
+export function dayOfWeekForLocalDate(localDate: string): number {
+  if (!LOCAL_DATE_PATTERN.test(localDate)) {
+    throw new Error("date must use YYYY-MM-DD format");
+  }
+
+  return new Date(`${localDate}T00:00:00.000Z`).getUTCDay();
+}
+
+function isValidOpenWindow(window: BusinessHourRecord): window is OpenWindow {
+  return (
+    WALL_CLOCK_PATTERN.test(window.opensAt) &&
+    WALL_CLOCK_PATTERN.test(window.closesAt) &&
+    window.opensAt < window.closesAt
+  );
+}
+
+export async function getOpenWindows(
+  tenantId: string,
+  date: Date | string,
+  db: AvailabilityPrisma = prisma as unknown as AvailabilityPrisma
+): Promise<OpenWindow[]> {
+  const normalizedTenantId = tenantId.trim();
+  if (!normalizedTenantId) {
+    throw new Error("tenantId is required");
+  }
+
+  const localDate = toTenantLocalDate(date);
+  const blackout = await db.blackout.findFirst({
+    where: {
+      tenantId: normalizedTenantId,
+      date: localDate,
+    },
+    select: { id: true },
+  });
+
+  if (blackout) {
+    return [];
+  }
+
+  const businessHours = await db.businessHour.findMany({
+    where: {
+      tenantId: normalizedTenantId,
+      dayOfWeek: dayOfWeekForLocalDate(localDate),
+    },
+    orderBy: [{ opensAt: "asc" }, { closesAt: "asc" }],
+    select: {
+      opensAt: true,
+      closesAt: true,
+    },
+  });
+
+  return businessHours.filter(isValidOpenWindow).map((window) => ({
+    opensAt: window.opensAt,
+    closesAt: window.closesAt,
+  }));
+}

--- a/app/lib/schedule/schemas.ts
+++ b/app/lib/schedule/schemas.ts
@@ -1,0 +1,55 @@
+import { z } from "zod";
+
+const timeSchema = z.string().regex(/^([01]\d|2[0-3]):[0-5]\d$/, "Use HH:mm time");
+const dateSchema = z.string().regex(/^\d{4}-\d{2}-\d{2}$/, "Use YYYY-MM-DD date");
+
+export const businessHourSchema = z
+  .object({
+    dayOfWeek: z.coerce.number().int().min(0).max(6),
+    opensAt: timeSchema,
+    closesAt: timeSchema,
+  })
+  .refine((value) => value.opensAt < value.closesAt, {
+    message: "Opening time must be before closing time",
+    path: ["closesAt"],
+  });
+
+export const blackoutSchema = z.object({
+  date: dateSchema,
+  reason: z.string().trim().max(120).optional().default(""),
+});
+
+export const updateScheduleSchema = z
+  .object({
+    businessHours: z.array(businessHourSchema).max(42),
+    blackouts: z.array(blackoutSchema).max(50),
+  })
+  .superRefine((value, ctx) => {
+    const blackoutDates = new Set<string>();
+
+    value.blackouts.forEach((blackout, index) => {
+      if (blackoutDates.has(blackout.date)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: "Blackout date must be unique",
+          path: ["blackouts", index, "date"],
+        });
+      }
+
+      blackoutDates.add(blackout.date);
+    });
+  });
+
+export type UpdateScheduleInput = z.infer<typeof updateScheduleSchema>;
+
+export function normalizeScheduleInput(input: UpdateScheduleInput): UpdateScheduleInput {
+  return {
+    businessHours: [...input.businessHours].sort(
+      (left, right) =>
+        left.dayOfWeek - right.dayOfWeek ||
+        left.opensAt.localeCompare(right.opensAt) ||
+        left.closesAt.localeCompare(right.closesAt)
+    ),
+    blackouts: [...input.blackouts].sort((left, right) => left.date.localeCompare(right.date)),
+  };
+}

--- a/app/lib/tenant-guard.ts
+++ b/app/lib/tenant-guard.ts
@@ -5,6 +5,7 @@ export const TENANT_SCOPED_MODELS = [
   "Service",
   "Staff",
   "BusinessHour",
+  "Blackout",
   "Client",
   "Booking",
   "Payment",

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -35,8 +35,8 @@ The root of the multi-tenant tree.
 | `timezone` | `String` | IANA tz, defaults to `Africa/Lagos`    |
 | `currency` | `String` | ISO 4217, defaults to `NGN`            |
 
-Children: `users`, `services`, `staff`, `businessHours`, `clients`, `bookings`,
-`payments`, `auditLogs`.
+Children: `users`, `services`, `staff`, `businessHours`, `blackouts`,
+`clients`, `bookings`, `payments`, `auditLogs`.
 
 ### User
 
@@ -79,19 +79,34 @@ member also logs in.
 
 ### BusinessHour
 
-Weekly availability template. Rows with `staffId = null` define the tenant's
-default hours; rows with a `staffId` override for that staff member.
+Weekly availability template for a tenant. Multiple rows may share the same
+weekday so a tenant can define split-day hours such as 09:00-12:00 and
+14:00-18:00.
 
-| Column        | Type        | Notes                                           |
-|---------------|-------------|-------------------------------------------------|
-| `tenantId`    | `String`    | FK → `Tenant.id`, indexed                       |
-| `staffId`     | `String?`   | Optional FK → `Staff.id`                        |
-| `dayOfWeek`   | `DayOfWeek` | Enum                                            |
-| `openMinute`  | `Int`       | Minutes since midnight (`9*60` → 09:00)         |
-| `closeMinute` | `Int`       | Minutes since midnight                          |
+| Column      | Type     | Notes                                |
+|-------------|----------|--------------------------------------|
+| `tenantId`  | `String` | FK → `Tenant.id`, indexed            |
+| `dayOfWeek` | `Int`    | Weekday number used by availability  |
+| `opensAt`   | `String` | Local wall-clock time, `HH:mm`       |
+| `closesAt`  | `String` | Local wall-clock time, `HH:mm`       |
 
-Composite index `@@index([tenantId, staffId, dayOfWeek])` supports the
-availability lookup path.
+Composite index `@@index([tenantId, dayOfWeek])` supports the availability
+lookup path without enforcing one row per weekday.
+
+### Blackout
+
+Tenant-specific closure dates such as public holidays or owner-entered shop
+closures. A blackout suppresses the weekly business-hour template for its
+tenant-local date.
+
+| Column     | Type      | Notes                                  |
+|------------|-----------|----------------------------------------|
+| `tenantId` | `String`  | FK → `Tenant.id`, indexed              |
+| `date`     | `String`  | Tenant-local date, `YYYY-MM-DD`        |
+| `reason`   | `String?` | Optional owner-facing closure reason   |
+
+`@@unique([tenantId, date])` keeps a tenant from creating duplicate blackout
+rows for the same local date.
 
 ### Client
 
@@ -163,7 +178,8 @@ Every tenant-scoped table has at least `@@index([tenantId])`:
 | `User`         | ✓            | `@@unique([tenantId, email])`                     |
 | `Service`      | ✓            | —                                                 |
 | `Staff`        | ✓            | `@unique` on `userId`                             |
-| `BusinessHour` | ✓            | `@@index([tenantId, staffId, dayOfWeek])`         |
+| `BusinessHour` | ✓            | `@@index([tenantId, dayOfWeek])`                  |
+| `Blackout`     | ✓            | `@@unique([tenantId, date])`                      |
 | `Client`       | ✓            | `@@unique([tenantId, phone])`, `…email]`          |
 | `Booking`      | ✓            | `…startsAt`, `…staffId, startsAt`                 |
 | `Payment`      | ✓            | `@@index([tenantId, bookingId])`                  |

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test": "vitest run",
     "lighthouse:mobile": "lhci autorun --config=lighthouserc.json",
     "prisma:generate": "prisma generate",
+    "postinstall": "prisma generate",
     "migrate:dev": "prisma migrate dev",
     "db:seed": "prisma db seed"
   },

--- a/prisma/migrations/20260708000000_add_schedule_blackouts/migration.sql
+++ b/prisma/migrations/20260708000000_add_schedule_blackouts/migration.sql
@@ -1,0 +1,22 @@
+-- CreateTable
+CREATE TABLE "Blackout" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "tenantId" TEXT NOT NULL,
+    "date" TEXT NOT NULL,
+    "reason" TEXT,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "Blackout_tenantId_fkey" FOREIGN KEY ("tenantId") REFERENCES "Tenant" ("id") ON DELETE CASCADE ON UPDATE CASCADE
+);
+
+-- DropIndex
+DROP INDEX "BusinessHour_tenantId_dayOfWeek_key";
+
+-- CreateIndex
+CREATE INDEX "BusinessHour_tenantId_dayOfWeek_idx" ON "BusinessHour"("tenantId", "dayOfWeek");
+
+-- CreateIndex
+CREATE INDEX "Blackout_tenantId_idx" ON "Blackout"("tenantId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "Blackout_tenantId_date_key" ON "Blackout"("tenantId", "date");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -23,6 +23,7 @@ model Tenant {
   services      Service[]
   staff         Staff[]
   businessHours BusinessHour[]
+  blackouts     Blackout[]
   clients       Client[]
   bookings      Booking[]
   payments      Payment[]
@@ -84,11 +85,23 @@ model BusinessHour {
   dayOfWeek Int
   opensAt   String
   closesAt  String
-  isClosed  Boolean  @default(false)
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
-  @@unique([tenantId, dayOfWeek])
+  @@index([tenantId])
+  @@index([tenantId, dayOfWeek])
+}
+
+model Blackout {
+  id        String   @id @default(cuid())
+  tenantId  String
+  tenant    Tenant   @relation(fields: [tenantId], references: [id], onDelete: Cascade)
+  date      String
+  reason    String?
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@unique([tenantId, date])
   @@index([tenantId])
 }
 
@@ -167,4 +180,3 @@ model AuditLog {
   @@index([tenantId])
   @@index([tenantId, entityType, entityId])
 }
-

--- a/tools/langchain_client.py
+++ b/tools/langchain_client.py
@@ -100,9 +100,7 @@ def _resolve_model(model: str | None) -> str:
 def _default_slots() -> list[SlotDefinition]:
     return [
         SlotDefinition(name="slot1", provider=PROVIDER_OPENAI, model="gpt-5.5"),
-        SlotDefinition(
-            name="slot2", provider=PROVIDER_ANTHROPIC, model="claude-opus-4-7"
-        ),
+        SlotDefinition(name="slot2", provider=PROVIDER_ANTHROPIC, model="claude-opus-4-7"),
         SlotDefinition(name="slot3", provider=PROVIDER_GITHUB, model="gpt-4.1"),
     ]
 


### PR DESCRIPTION
<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
PR #111 addressed issue #110 but verification identified concerns (verdict: **CONCERNS**). Provider verdicts split with high-confidence concerns; dissenting confidence 0.86 >= 0.85. Requires human review before starting another automated follow-up. This follow-up addresses the remaining gaps with improved task structure.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#111](https://github.com/iamkayleb/bukay/issues/111)
- [#110](https://github.com/iamkayleb/bukay/issues/110)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Human review required to reconcile split verdicts before automating another follow-up.

#### Acceptance criteria
- [x] Owner can set different hours per weekday
- [x] Blackout dates return no windows
- [x] Helper used by availability engine

<!-- auto-status-summary:end -->

<details>

<summary>Full Issue Text</summary>



## Why

PR #111 addressed issue #110 but verification identified concerns (verdict: **CONCERNS**). Provider verdicts split with high-confidence concerns; dissenting confidence 0.86 >= 0.85. Requires human review before starting another automated follow-up. This follow-up addresses the remaining gaps with improved task structure.

## Source

- Original PR: #111
- Parent issue: #110

## Scope

Address verification concerns from PR #111 related to Business hours + blackout dates.

## Tasks

- [ ] Human review required to reconcile split verdicts before automating another follow-up.

## Acceptance Criteria

- [x] Owner can set different hours per weekday
- [x] Blackout dates return no windows
- [x] Helper used by availability engine

## Notes
<details>
<summary>Advisory items (non-blocking)</summary>

- `toTenantLocalDate(Date)` uses `toISOString().slice(0, 10)`, which treats `Date` inputs as UTC rather than resolving a tenant-local date from the tenant timezone. This is acceptable for direct `YYYY-MM-DD` strings, but could cause date drift if callers pass Date objects representing local tenant dates.
- DST handling relies on string dates and UTC parsing; comment claims 'DST-free zone' (Africa/Lagos) but no explicit timezone handling — acceptable given tenant tz default but fragile if timezones expand.
- comment claims 'DST-free zone' (Africa/Lagos) but no explicit timezone handling — acceptable given tenant tz default but fragile if timezones expand.

</details>

## verify:compare Analysis

- Resolved verdict: CONCERNS
- Concern: The acceptance criterion "Helper used by availability engine" does not appear to be satisfied in the provided diff. `getOpenWindows` is added and tested, but no existing availability/booking slot generation code is modified to call it, so blackout dates and multi-window schedules may not affect actual availability behavior.
- Concern: The settings API shown uses tenant context via `runForTenant`, but the diff does not show explicit owner-only authorization for schedule updates. If only owners should be allowed to edit hours, this may be incomplete.
- Concern: BusinessHour migration drops the previous unique index but the schema also removes the isClosed field without a corresponding DROP COLUMN in migration.sql, which may leave schema drift in existing databases.
- Concern: The availability helper is defined but the diff does not show it wired into an actual availability engine caller; acceptance says 'Helper used by availability engine' - callers may exist elsewhere but are not visible in this PR.
- Concern: Casting prisma via `as unknown as` to bypass types suggests Prisma client may not yet have Blackout typed (likely due to generation timing); functionally fine but a code smell.
- Concern: The availability helper is defined but the diff does not show it wired into an actual availability engine caller
- Concern: acceptance says 'Helper used by availability engine' - callers may exist elsewhere but are not visible in this PR.
- Concern: Casting prisma via `as unknown as` to bypass types suggests Prisma client may not yet have Blackout typed (likely due to generation timing)
- Concern: functionally fine but a code smell.
- Concern: DST handling relies on string dates and UTC parsing
- Advisory: `toTenantLocalDate(Date)` uses `toISOString().slice(0, 10)`, which treats `Date` inputs as UTC rather than resolving a tenant-local date from the tenant timezone. This is acceptable for direct `YYYY-MM-DD` strings, but could cause date drift if callers pass Date objects representing local tenant dates.
- Advisory: DST handling relies on string dates and UTC parsing; comment claims 'DST-free zone' (Africa/Lagos) but no explicit timezone handling — acceptable given tenant tz default but fragile if timezones expand.
- Advisory: comment claims 'DST-free zone' (Africa/Lagos) but no explicit timezone handling — acceptable given tenant tz default but fragile if timezones expand.

## verify:compare Evidence

- openai: CONCERNS @ 86% (The PR substantially implements the schedule data model, API, UI, helper, tenant guard updates, docs, migration, and unit tests. Owners can configure multiple weekly windows per weekday through the...)
- anthropic: PASS @ 80% (The PR adds a Blackout model, updates BusinessHour to support multiple windows per weekday, provides a Zod-validated PUT/GET API for schedule settings, a client-side settings UI, and a getOpenWindo...)

## Background Context

<details>
<summary>Verification analysis details</summary>

### Provider Verdicts

- **openai**: CONCERNS @ 86%
- **anthropic**: PASS @ 80%

</details>

---
*Auto-generated by followup-issue-generator*



</details>

—
PR created automatically to engage Codex.

<!-- pr-preamble:start -->
> **Source:** Issue #120

<!-- pr-preamble:end -->