### PR TITLE
Codex bootstrap for #149

### DIFF
--- a/__tests__/app/api/bookings/route.test.ts
+++ b/__tests__/app/api/bookings/route.test.ts
@@ -1,0 +1,258 @@
+import { NextRequest } from "next/server";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+type BookingRow = {
+  id: string;
+  tenantId: string;
+  clientId: string;
+  serviceId: string;
+  staffId: string | null;
+  startsAt: Date;
+  endsAt: Date;
+  status: string;
+  notes: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+type BusinessHourRow = {
+  id: string;
+  tenantId: string;
+  dayOfWeek: number;
+  opensAt: string;
+  closesAt: string;
+  isClosed: boolean;
+};
+
+type NextRequestInit = NonNullable<ConstructorParameters<typeof NextRequest>[1]>;
+
+const state = vi.hoisted(() => ({
+  bookings: [] as BookingRow[],
+  businessHours: [] as BusinessHourRow[],
+  findBookingFirst: vi.fn(),
+  findBookingMany: vi.fn(),
+  updateBooking: vi.fn(),
+  findBusinessHourFirst: vi.fn(),
+  findBlackoutDateFirst: vi.fn(),
+  tenantFindUnique: vi.fn(),
+}));
+
+vi.mock("@/app/db/prisma", () => ({
+  prisma: {
+    booking: {
+      findFirst: state.findBookingFirst,
+      findMany: state.findBookingMany,
+      update: state.updateBooking,
+    },
+    businessHour: {
+      findFirst: state.findBusinessHourFirst,
+    },
+    blackoutDate: {
+      findFirst: state.findBlackoutDateFirst,
+    },
+    tenant: {
+      findUnique: state.tenantFindUnique,
+    },
+  },
+}));
+
+import { PATCH } from "@/app/api/bookings/[id]/route";
+
+function booking(overrides: Partial<BookingRow> = {}): BookingRow {
+  return {
+    id: "booking-1",
+    tenantId: "tenant-1",
+    clientId: "client-1",
+    serviceId: "service-1",
+    staffId: "staff-1",
+    startsAt: new Date("2026-07-27T10:00:00.000Z"),
+    endsAt: new Date("2026-07-27T11:00:00.000Z"),
+    status: "confirmed",
+    notes: null,
+    createdAt: new Date("2026-07-01T10:00:00.000Z"),
+    updatedAt: new Date("2026-07-01T10:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+function request(path: string, body: unknown, init: NextRequestInit = {}) {
+  return new NextRequest(`http://app.test${path}`, {
+    ...init,
+    method: init.method ?? "PATCH",
+    headers: {
+      "content-type": "application/json",
+      "x-tenant-id": "tenant-1",
+      ...(init.headers as Record<string, string> | undefined),
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+beforeEach(() => {
+  state.bookings = [booking()];
+  state.businessHours = [
+    {
+      id: "hours-1",
+      tenantId: "tenant-1",
+      dayOfWeek: 1,
+      opensAt: "09:00",
+      closesAt: "17:00",
+      isClosed: false,
+    },
+  ];
+
+  state.findBookingFirst.mockReset();
+  state.findBookingMany.mockReset();
+  state.updateBooking.mockReset();
+  state.findBusinessHourFirst.mockReset();
+  state.findBlackoutDateFirst.mockReset();
+  state.tenantFindUnique.mockReset();
+
+  state.findBookingFirst.mockImplementation(
+    async (args: { where: { tenantId: string; id: string } }) =>
+      state.bookings.find(
+        (row) => row.tenantId === args.where.tenantId && row.id === args.where.id
+      ) ?? null
+  );
+  state.findBookingMany.mockImplementation(
+    async (args: {
+      where: {
+        tenantId: string;
+        id: { not: string };
+        staffId: string | null;
+        startsAt: { lt: Date };
+        endsAt: { gt: Date };
+      };
+      take: number;
+    }) =>
+      state.bookings
+        .filter(
+          (row) =>
+            row.tenantId === args.where.tenantId &&
+            row.id !== args.where.id.not &&
+            row.staffId === args.where.staffId &&
+            row.startsAt < args.where.startsAt.lt &&
+            row.endsAt > args.where.endsAt.gt
+        )
+        .slice(0, args.take)
+  );
+  state.updateBooking.mockImplementation(
+    async (args: { where: { id: string }; data: Partial<BookingRow> }) => {
+      const index = state.bookings.findIndex((row) => row.id === args.where.id);
+      if (index === -1) {
+        throw Object.assign(new Error("Record not found"), { code: "P2025" });
+      }
+
+      const row = booking({
+        ...state.bookings[index],
+        ...args.data,
+        updatedAt: new Date("2026-07-27T12:00:00.000Z"),
+      });
+      state.bookings[index] = row;
+      return row;
+    }
+  );
+  state.findBusinessHourFirst.mockImplementation(
+    async (args: { where: { tenantId: string; dayOfWeek: number } }) =>
+      state.businessHours.find(
+        (row) => row.tenantId === args.where.tenantId && row.dayOfWeek === args.where.dayOfWeek
+      ) ?? null
+  );
+  state.findBlackoutDateFirst.mockResolvedValue(null);
+});
+
+describe("PATCH /api/bookings/:id", () => {
+  it("rejects a startsAt-only update when the merged interval is outside business hours", async () => {
+    const res = await PATCH(
+      request("/api/bookings/booking-1", { startsAt: "2026-07-27T08:30:00.000Z" }),
+      { params: { id: "booking-1" } }
+    );
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("OUTSIDE_BUSINESS_HOURS");
+    expect(body.message).toContain("outside configured business hours");
+    expect(state.findBookingMany).not.toHaveBeenCalled();
+    expect(state.updateBooking).not.toHaveBeenCalled();
+  });
+
+  it("rejects an endsAt-only update when the merged interval is outside business hours", async () => {
+    const res = await PATCH(
+      request("/api/bookings/booking-1", { endsAt: "2026-07-27T17:30:00.000Z" }),
+      { params: { id: "booking-1" } }
+    );
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("OUTSIDE_BUSINESS_HOURS");
+    expect(body.message).toContain("outside configured business hours");
+    expect(state.findBookingMany).not.toHaveBeenCalled();
+    expect(state.updateBooking).not.toHaveBeenCalled();
+  });
+
+  it("rejects a startsAt-only update when the merged interval overlaps another booking", async () => {
+    state.bookings.push(
+      booking({
+        id: "booking-2",
+        startsAt: new Date("2026-07-27T09:30:00.000Z"),
+        endsAt: new Date("2026-07-27T10:15:00.000Z"),
+      })
+    );
+
+    const res = await PATCH(
+      request("/api/bookings/booking-1", { startsAt: "2026-07-27T09:45:00.000Z" }),
+      { params: { id: "booking-1" } }
+    );
+
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.error).toBe("BOOKING_OVERLAP");
+    expect(body.message).toContain("overlaps with another booking");
+    expect(state.findBookingMany).toHaveBeenCalledWith({
+      where: {
+        tenantId: "tenant-1",
+        id: { not: "booking-1" },
+        staffId: "staff-1",
+        startsAt: { lt: new Date("2026-07-27T11:00:00.000Z") },
+        endsAt: { gt: new Date("2026-07-27T09:45:00.000Z") },
+      },
+      take: 1,
+    });
+    expect(state.updateBooking).not.toHaveBeenCalled();
+  });
+
+  it("rejects an endsAt-only update when the merged interval overlaps another booking", async () => {
+    state.bookings = [
+      booking({
+        startsAt: new Date("2026-07-27T09:00:00.000Z"),
+        endsAt: new Date("2026-07-27T10:00:00.000Z"),
+      }),
+      booking({
+        id: "booking-2",
+        startsAt: new Date("2026-07-27T10:30:00.000Z"),
+        endsAt: new Date("2026-07-27T11:30:00.000Z"),
+      }),
+    ];
+
+    const res = await PATCH(
+      request("/api/bookings/booking-1", { endsAt: "2026-07-27T11:00:00.000Z" }),
+      { params: { id: "booking-1" } }
+    );
+
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.error).toBe("BOOKING_OVERLAP");
+    expect(body.message).toContain("overlaps with another booking");
+    expect(state.findBookingMany).toHaveBeenCalledWith({
+      where: {
+        tenantId: "tenant-1",
+        id: { not: "booking-1" },
+        staffId: "staff-1",
+        startsAt: { lt: new Date("2026-07-27T11:00:00.000Z") },
+        endsAt: { gt: new Date("2026-07-27T09:00:00.000Z") },
+      },
+      take: 1,
+    });
+    expect(state.updateBooking).not.toHaveBeenCalled();
+  });
+});

--- a/agents/codex-149.md
+++ b/agents/codex-149.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for codex on issue #149 -->

--- a/api/bookings.ts
+++ b/api/bookings.ts
@@ -1,0 +1,193 @@
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+
+import { prisma } from "@/app/db/prisma";
+import {
+  isMissingRecordError,
+  jsonError,
+  readJson,
+  runForTenant,
+  validationError,
+} from "@/app/api/services/_helpers";
+import {
+  mergeBookingInterval,
+  validateBookingInterval,
+  type BookingRecord,
+  type BookingValidationStore,
+  type BusinessHourRecord,
+} from "@/services/bookingValidation";
+
+export const dynamic = "force-dynamic";
+
+type RouteContext = {
+  params: {
+    id: string;
+  };
+};
+
+type BookingUpdateData = {
+  startsAt?: Date;
+  endsAt?: Date;
+  staffId?: string | null;
+  status?: string;
+  notes?: string | null;
+};
+
+const bookingDateField = z.preprocess(
+  (value) => {
+    if (typeof value !== "string") {
+      return value;
+    }
+
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? value : date;
+  },
+  z.date({ invalid_type_error: "Must be a valid ISO date" })
+);
+
+const updateBookingSchema = z
+  .object({
+    startsAt: bookingDateField.optional(),
+    endsAt: bookingDateField.optional(),
+    staffId: z.string().trim().min(1, "Staff is required").nullable().optional(),
+    status: z.string().trim().min(1, "Status is required").optional(),
+    notes: z.string().nullable().optional(),
+  })
+  .strict()
+  .refine((value) => Object.keys(value).length > 0, {
+    message: "At least one booking field is required",
+    path: ["_form"],
+  });
+
+const bookingDelegate = prisma.booking as unknown as {
+  findFirst(args: unknown): Promise<BookingRecord | null>;
+  findMany(args: unknown): Promise<BookingRecord[]>;
+  update(args: unknown): Promise<BookingRecord>;
+};
+
+const businessHourDelegate = prisma.businessHour as unknown as {
+  findFirst(args: unknown): Promise<BusinessHourRecord | null>;
+};
+
+const blackoutDateDelegate = (
+  prisma as unknown as {
+    blackoutDate?: {
+      findFirst(args: unknown): Promise<unknown | null>;
+    };
+  }
+).blackoutDate;
+
+async function findTenantBooking(tenantId: string, id: string) {
+  return bookingDelegate.findFirst({
+    where: { tenantId, id },
+  });
+}
+
+function buildValidationStore(): BookingValidationStore {
+  return {
+    async findBusinessHours({ tenantId, dayOfWeek }) {
+      return businessHourDelegate.findFirst({
+        where: {
+          tenantId,
+          dayOfWeek,
+        },
+      });
+    },
+    async hasBlackoutDate({ tenantId, date, staffId }) {
+      if (!blackoutDateDelegate) {
+        return false;
+      }
+
+      const blackoutDate = await blackoutDateDelegate.findFirst({
+        where: {
+          tenantId,
+          date,
+          OR: staffId ? [{ staffId }, { staffId: null }] : [{ staffId: null }],
+        },
+      });
+
+      return !!blackoutDate;
+    },
+    async findOverlappingBooking({ tenantId, bookingId, staffId, startsAt, endsAt }) {
+      const overlappingBookings = await bookingDelegate.findMany({
+        where: {
+          tenantId,
+          id: { not: bookingId },
+          staffId,
+          startsAt: { lt: endsAt },
+          endsAt: { gt: startsAt },
+        },
+        take: 1,
+      });
+
+      return overlappingBookings[0] ?? null;
+    },
+  };
+}
+
+export async function PATCH(req: NextRequest, { params }: RouteContext) {
+  const body = await readJson(req);
+  if (body instanceof NextResponse) {
+    return body;
+  }
+
+  const parsed = updateBookingSchema.safeParse(body);
+  if (!parsed.success) {
+    return validationError(parsed.error);
+  }
+
+  return runForTenant(req, async (tenantId) => {
+    try {
+      const existingBooking = await findTenantBooking(tenantId, params.id);
+      if (!existingBooking) {
+        return jsonError("BOOKING_NOT_FOUND", 404);
+      }
+
+      const updateData: BookingUpdateData = parsed.data;
+      const candidateInterval = mergeBookingInterval(existingBooking, {
+        startsAt: updateData.startsAt,
+        endsAt: updateData.endsAt,
+      });
+      const validationIssue = await validateBookingInterval(
+        buildValidationStore(),
+        existingBooking,
+        {
+          ...candidateInterval,
+          staffId: updateData.staffId ?? existingBooking.staffId,
+        }
+      );
+
+      if (validationIssue) {
+        return NextResponse.json(
+          {
+            ok: false,
+            error: validationIssue.code,
+            message: validationIssue.message,
+          },
+          { status: validationIssue.status }
+        );
+      }
+
+      const booking = await bookingDelegate.update({
+        where: { id: existingBooking.id },
+        data: updateData,
+      });
+
+      return NextResponse.json({ ok: true, booking: serializeBooking(booking) });
+    } catch (error) {
+      if (isMissingRecordError(error)) {
+        return jsonError("BOOKING_NOT_FOUND", 404);
+      }
+
+      throw error;
+    }
+  });
+}
+
+function serializeBooking(booking: BookingRecord) {
+  return {
+    ...booking,
+    startsAt: booking.startsAt.toISOString(),
+    endsAt: booking.endsAt.toISOString(),
+  };
+}

--- a/app/api/bookings/[id]/route.ts
+++ b/app/api/bookings/[id]/route.ts
@@ -1,0 +1,1 @@
+export { dynamic, PATCH } from "@/api/bookings";

--- a/services/bookingValidation.ts
+++ b/services/bookingValidation.ts
@@ -1,0 +1,192 @@
+export type BookingInterval = {
+  startsAt: Date;
+  endsAt: Date;
+};
+
+export type BookingRecord = BookingInterval & {
+  id: string;
+  tenantId: string;
+  staffId: string | null;
+};
+
+export type BusinessHourRecord = {
+  opensAt: string;
+  closesAt: string;
+  isClosed: boolean;
+};
+
+export type BookingValidationIssue =
+  | {
+      code: "OUTSIDE_BUSINESS_HOURS";
+      status: 400;
+      message: string;
+    }
+  | {
+      code: "BOOKING_OVERLAP";
+      status: 409;
+      message: string;
+    };
+
+export type BookingValidationStore = {
+  findBusinessHours(args: {
+    tenantId: string;
+    dayOfWeek: number;
+    staffId: string | null;
+  }): Promise<BusinessHourRecord | null>;
+  hasBlackoutDate(args: {
+    tenantId: string;
+    date: string;
+    staffId: string | null;
+  }): Promise<boolean>;
+  findOverlappingBooking(args: {
+    tenantId: string;
+    bookingId: string;
+    staffId: string | null;
+    startsAt: Date;
+    endsAt: Date;
+  }): Promise<BookingRecord | null>;
+};
+
+const TIME_PATTERN = /^(\d{2}):(\d{2})$/;
+
+export function mergeBookingInterval(
+  existing: BookingInterval,
+  update: Partial<BookingInterval>
+): BookingInterval {
+  return {
+    startsAt: update.startsAt ?? existing.startsAt,
+    endsAt: update.endsAt ?? existing.endsAt,
+  };
+}
+
+export async function validateBookingInterval(
+  store: BookingValidationStore,
+  existing: BookingRecord,
+  candidate: BookingInterval & { staffId?: string | null }
+): Promise<BookingValidationIssue | null> {
+  const staffId = candidate.staffId ?? existing.staffId;
+  const intervalIssue = validateIntervalShape(candidate);
+  if (intervalIssue) {
+    return intervalIssue;
+  }
+
+  const businessHoursIssue = await validateBusinessHours(store, {
+    tenantId: existing.tenantId,
+    staffId,
+    startsAt: candidate.startsAt,
+    endsAt: candidate.endsAt,
+  });
+  if (businessHoursIssue) {
+    return businessHoursIssue;
+  }
+
+  const overlappingBooking = await store.findOverlappingBooking({
+    tenantId: existing.tenantId,
+    bookingId: existing.id,
+    staffId,
+    startsAt: candidate.startsAt,
+    endsAt: candidate.endsAt,
+  });
+  if (overlappingBooking) {
+    return {
+      code: "BOOKING_OVERLAP",
+      status: 409,
+      message: "Booking overlaps with another booking for the selected time.",
+    };
+  }
+
+  return null;
+}
+
+function validateIntervalShape(interval: BookingInterval): BookingValidationIssue | null {
+  if (interval.endsAt <= interval.startsAt) {
+    return {
+      code: "OUTSIDE_BUSINESS_HOURS",
+      status: 400,
+      message: "Booking end time must be after the start time.",
+    };
+  }
+
+  if (toUtcDateKey(interval.startsAt) !== toUtcDateKey(interval.endsAt)) {
+    return {
+      code: "OUTSIDE_BUSINESS_HOURS",
+      status: 400,
+      message: "Booking must start and end on the same business day.",
+    };
+  }
+
+  return null;
+}
+
+async function validateBusinessHours(
+  store: BookingValidationStore,
+  interval: BookingInterval & { tenantId: string; staffId: string | null }
+): Promise<BookingValidationIssue | null> {
+  const date = toUtcDateKey(interval.startsAt);
+  const hasBlackoutDate = await store.hasBlackoutDate({
+    tenantId: interval.tenantId,
+    staffId: interval.staffId,
+    date,
+  });
+  if (hasBlackoutDate) {
+    return {
+      code: "OUTSIDE_BUSINESS_HOURS",
+      status: 400,
+      message: "Booking falls on a blackout date.",
+    };
+  }
+
+  const businessHours = await store.findBusinessHours({
+    tenantId: interval.tenantId,
+    staffId: interval.staffId,
+    dayOfWeek: interval.startsAt.getUTCDay(),
+  });
+  if (!businessHours || businessHours.isClosed) {
+    return {
+      code: "OUTSIDE_BUSINESS_HOURS",
+      status: 400,
+      message: "Booking falls outside configured business hours.",
+    };
+  }
+
+  const opensAt = parseClockMinutes(businessHours.opensAt);
+  const closesAt = parseClockMinutes(businessHours.closesAt);
+  if (opensAt === null || closesAt === null || closesAt <= opensAt) {
+    return {
+      code: "OUTSIDE_BUSINESS_HOURS",
+      status: 400,
+      message: "Configured business hours are invalid for this day.",
+    };
+  }
+
+  const startMinute = interval.startsAt.getUTCHours() * 60 + interval.startsAt.getUTCMinutes();
+  const endMinute = interval.endsAt.getUTCHours() * 60 + interval.endsAt.getUTCMinutes();
+  if (startMinute < opensAt || endMinute > closesAt) {
+    return {
+      code: "OUTSIDE_BUSINESS_HOURS",
+      status: 400,
+      message: "Booking falls outside configured business hours.",
+    };
+  }
+
+  return null;
+}
+
+function parseClockMinutes(value: string): number | null {
+  const match = TIME_PATTERN.exec(value);
+  if (!match) {
+    return null;
+  }
+
+  const hours = Number(match[1]);
+  const minutes = Number(match[2]);
+  if (hours > 23 || minutes > 59) {
+    return null;
+  }
+
+  return hours * 60 + minutes;
+}
+
+function toUtcDateKey(value: Date) {
+  return value.toISOString().slice(0, 10);
+}


### PR DESCRIPTION
<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
PR #145 addressed issue #143 but verification identified concerns (verdict: **CONCERNS**). This follow-up addresses the remaining gaps with improved task structure to ensure that partial updates to bookings cannot bypass business hours or overlap validations.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#145](https://github.com/iamkayleb/bukay/issues/145)
- [#143](https://github.com/iamkayleb/bukay/issues/143)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [x] Update the PATCH /api/bookings/:id handler in `api/bookings.ts` to always compute the candidate booking interval by merging any provided startsAt and/or endsAt values with the existing booking's values, and run business hours and overlap validations on the resulting interval, regardless of which boundaries are supplied.
- [x] Add or update tests in `tests/api/bookings.test.ts` for PATCH /api/bookings/:id requests that only provide startsAt or endsAt (not both), verifying that business hours and overlap validations are enforced in these cases.
- [x] Update or centralize validation logic in `services/bookingValidation.ts` to support interval validation for partial updates.

#### Acceptance criteria
- [x] PATCH /api/bookings/:id returns HTTP 400 with error code 'OUTSIDE_BUSINESS_HOURS' and a descriptive message when a request provides only startsAt or only endsAt, and the resulting interval (using the other boundary from the existing booking) falls outside configured business hours or on a blackout date.
- [x] PATCH /api/bookings/:id returns HTTP 409 with error code 'BOOKING_OVERLAP' and a descriptive message when a request provides only startsAt or only endsAt, and the resulting interval (using the other boundary from the existing booking) overlaps with another booking.
- [x] The PATCH /api/bookings/:id handler in `api/bookings.ts` always computes the candidate booking interval by merging any provided startsAt and/or endsAt values with the existing booking's values, and runs business hours and overlap validations on the resulting interval regardless of which boundaries are supplied.
- [x] Tests in `tests/api/bookings.test.ts` pass for PATCH requests that only provide startsAt or only endsAt, confirming business hours and overlap validations are enforced.

<!-- auto-status-summary:end -->

<details>

<summary>Full Issue Text</summary>



## Why

PR #145 addressed issue #143 but verification identified concerns (verdict: **CONCERNS**). This follow-up addresses the remaining gaps with improved task structure to ensure that partial updates to bookings cannot bypass business hours or overlap validations.

## Scope

_Not provided._

## Non-Goals

_Not provided._

## Tasks

- [ ] Update the PATCH /api/bookings/:id handler in `api/bookings.ts` to always compute the candidate booking interval by merging any provided startsAt and/or endsAt values with the existing booking's values, and run business hours and overlap validations on the resulting interval, regardless of which boundaries are supplied.
- [ ] Add or update tests in `tests/api/bookings.test.ts` for PATCH /api/bookings/:id requests that only provide startsAt or endsAt (not both), verifying that business hours and overlap validations are enforced in these cases.
- [ ] Update or centralize validation logic in `services/bookingValidation.ts` to support interval validation for partial updates.

## Acceptance Criteria

- [ ] PATCH /api/bookings/:id returns HTTP 400 with error code 'OUTSIDE_BUSINESS_HOURS' and a descriptive message when a request provides only startsAt or only endsAt, and the resulting interval (using the other boundary from the existing booking) falls outside configured business hours or on a blackout date.
- [ ] PATCH /api/bookings/:id returns HTTP 409 with error code 'BOOKING_OVERLAP' and a descriptive message when a request provides only startsAt or only endsAt, and the resulting interval (using the other boundary from the existing booking) overlaps with another booking.
- [ ] The PATCH /api/bookings/:id handler in `api/bookings.ts` always computes the candidate booking interval by merging any provided startsAt and/or endsAt values with the existing booking's values, and runs business hours and overlap validations on the resulting interval regardless of which boundaries are supplied.
- [ ] Tests in `tests/api/bookings.test.ts` pass for PATCH requests that only provide startsAt or only endsAt, confirming business hours and overlap validations are enforced.

## Implementation Notes

Update `api/bookings.ts` to always derive the candidate interval from the combination of provided and existing startsAt/endsAt values, and ensure business hours and overlap validations are run on this interval, even if only one boundary is supplied.
Update or add tests in `tests/api/bookings.test.ts` to cover PATCH requests that only provide startsAt or only endsAt, ensuring that business hours and overlap validations are enforced.
Validation logic may need to be updated or centralized in `services/bookingValidation.ts` to support this behavior.



</details>

—
PR created automatically to engage Codex.

<!-- pr-preamble:start -->
> **Source:** Issue #149

<!-- pr-preamble:end -->