### PR TITLE
fix: resolve CI failures

### DIFF
--- a/tools/langchain_client.py
+++ b/tools/langchain_client.py
@@ -100,9 +100,7 @@ def _resolve_model(model: str | None) -> str:
 def _default_slots() -> list[SlotDefinition]:
     return [
         SlotDefinition(name="slot1", provider=PROVIDER_OPENAI, model="gpt-5.5"),
-        SlotDefinition(
-            name="slot2", provider=PROVIDER_ANTHROPIC, model="claude-opus-4-7"
-        ),
+        SlotDefinition(name="slot2", provider=PROVIDER_ANTHROPIC, model="claude-opus-4-7"),
         SlotDefinition(name="slot3", provider=PROVIDER_GITHUB, model="gpt-4.1"),
     ]
 


### PR DESCRIPTION
<!-- pr-preamble:start -->
> **Source:** Issue #149

<!-- pr-preamble:end -->

<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
PR #145 addressed issue #143 but verification identified concerns (verdict: **CONCERNS**). This follow-up addresses the remaining gaps with improved task structure to ensure that partial updates to bookings cannot bypass business hours or overlap validations.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#145](https://github.com/iamkayleb/bukay/issues/145)
- [#143](https://github.com/iamkayleb/bukay/issues/143)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [ ] Update the PATCH /api/bookings/:id handler in `api/bookings.ts` to always compute the candidate booking interval by merging any provided startsAt and/or endsAt values with the existing booking's values, and run business hours and overlap validations on the resulting interval, regardless of which boundaries are supplied.
- [ ] Add or update tests in `tests/api/bookings.test.ts` for PATCH /api/bookings/:id requests that only provide startsAt or endsAt (not both), verifying that business hours and overlap validations are enforced in these cases.
- [ ] Update or centralize validation logic in `services/bookingValidation.ts` to support interval validation for partial updates.

#### Acceptance criteria
- [ ] PATCH /api/bookings/:id returns HTTP 400 with error code 'OUTSIDE_BUSINESS_HOURS' and a descriptive message when a request provides only startsAt or only endsAt, and the resulting interval (using the other boundary from the existing booking) falls outside configured business hours or on a blackout date.
- [ ] PATCH /api/bookings/:id returns HTTP 409 with error code 'BOOKING_OVERLAP' and a descriptive message when a request provides only startsAt or only endsAt, and the resulting interval (using the other boundary from the existing booking) overlaps with another booking.
- [ ] The PATCH /api/bookings/:id handler in `api/bookings.ts` always computes the candidate booking interval by merging any provided startsAt and/or endsAt values with the existing booking's values, and runs business hours and overlap validations on the resulting interval regardless of which boundaries are supplied.
- [ ] Tests in `tests/api/bookings.test.ts` pass for PATCH requests that only provide startsAt or only endsAt, confirming business hours and overlap validations are enforced.

**Head SHA:** 267fb7854f3b658cddc07008438601bd64085a48
**Latest Runs:** ❔ in progress — Gate
**Required:** gate: ❔ in progress

| Workflow / Job | Result | Logs |
|----------------|--------|------|
| .github/workflows/autofix.yml | ❌ failure | [View run](https://github.com/iamkayleb/bukay/actions/runs/30268640791) |
| Agents PR Event Hub | ⏭️ skipped | [View run](https://github.com/iamkayleb/bukay/actions/runs/30274958243) |
| Agents PR Meta | ❔ in progress | [View run](https://github.com/iamkayleb/bukay/actions/runs/30274958117) |
| Dependabot Auto-merge | ⏭️ skipped | [View run](https://github.com/iamkayleb/bukay/actions/runs/30274902982) |
| Gate | ❔ in progress | [View run](https://github.com/iamkayleb/bukay/actions/runs/30274905499) |
| Health 45 Agents Guard | ✅ success | [View run](https://github.com/iamkayleb/bukay/actions/runs/30274904715) |
<!-- auto-status-summary:end -->