### PR TITLE
Codex bootstrap for #164

### DIFF
--- a/__tests__/app/api/bookings/route.test.ts
+++ b/__tests__/app/api/bookings/route.test.ts
@@ -137,8 +137,10 @@ beforeEach(() => {
         .slice(0, args.take)
   );
   state.updateBooking.mockImplementation(
-    async (args: { where: { id: string }; data: Partial<BookingRow> }) => {
-      const index = state.bookings.findIndex((row) => row.id === args.where.id);
+    async (args: { where: { id: string; tenantId: string }; data: Partial<BookingRow> }) => {
+      const index = state.bookings.findIndex(
+        (row) => row.id === args.where.id && row.tenantId === args.where.tenantId
+      );
       if (index === -1) {
         throw Object.assign(new Error("Record not found"), { code: "P2025" });
       }
@@ -162,6 +164,21 @@ beforeEach(() => {
 });
 
 describe("PATCH /api/bookings/:id", () => {
+  it("updates only a tenant-scoped booking", async () => {
+    const res = await PATCH(
+      request("/api/bookings/booking-1", { status: "cancelled", notes: "Client called" }),
+      { params: { id: "booking-1" } }
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.booking).toMatchObject({ id: "booking-1", status: "cancelled" });
+    expect(state.updateBooking).toHaveBeenCalledWith({
+      where: { id: "booking-1", tenantId: "tenant-1" },
+      data: { status: "cancelled", notes: "Client called" },
+    });
+  });
+
   it("rejects a startsAt-only update when the merged interval is outside business hours", async () => {
     const res = await PATCH(
       request("/api/bookings/booking-1", { startsAt: "2026-07-27T08:30:00.000Z" }),

--- a/__tests__/app/api/services/route.test.ts
+++ b/__tests__/app/api/services/route.test.ts
@@ -115,8 +115,10 @@ beforeEach(() => {
       ) ?? null
   );
   state.update.mockImplementation(
-    async (args: { where: { id: string }; data: Partial<ServiceRow> }) => {
-      const index = state.services.findIndex((row) => row.id === args.where.id);
+    async (args: { where: { id: string; tenantId: string }; data: Partial<ServiceRow> }) => {
+      const index = state.services.findIndex(
+        (row) => row.id === args.where.id && row.tenantId === args.where.tenantId
+      );
       if (index === -1) {
         throw Object.assign(new Error("Record not found"), { code: "P2025" });
       }
@@ -247,7 +249,7 @@ describe("/api/services", () => {
       where: { tenantId: "tenant-1", id: "service-1" },
     });
     expect(state.update).toHaveBeenCalledWith({
-      where: { id: "service-1" },
+      where: { id: "service-1", tenantId: "tenant-1" },
       data: { priceKobo: 900000, active: false },
     });
   });
@@ -294,7 +296,7 @@ describe("/api/services", () => {
       where: { tenantId: "tenant-1", id: "service-1" },
     });
     expect(state.update).toHaveBeenCalledWith({
-      where: { id: "service-1" },
+      where: { id: "service-1", tenantId: "tenant-1" },
       data: { active: false },
     });
   });

--- a/agents/codex-164.md
+++ b/agents/codex-164.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for codex on issue #164 -->

--- a/api/bookings.ts
+++ b/api/bookings.ts
@@ -169,7 +169,7 @@ export async function PATCH(req: NextRequest, { params }: RouteContext) {
       }
 
       const booking = await bookingDelegate.update({
-        where: { id: existingBooking.id },
+        where: { id: existingBooking.id, tenantId },
         data: updateData,
       });
 

--- a/app/api/services/[id]/route.ts
+++ b/app/api/services/[id]/route.ts
@@ -63,7 +63,7 @@ export async function PATCH(req: NextRequest, { params }: RouteContext) {
       }
 
       const service = await serviceDelegate.update({
-        where: { id: existingService.id },
+        where: { id: existingService.id, tenantId },
         data: parsed.data,
       });
 
@@ -91,7 +91,7 @@ export async function DELETE(req: NextRequest, { params }: RouteContext) {
       }
 
       const service = await serviceDelegate.update({
-        where: { id: existingService.id },
+        where: { id: existingService.id, tenantId },
         data: { active: false },
       });
 

--- a/tests/test_prisma_seed.py
+++ b/tests/test_prisma_seed.py
@@ -24,6 +24,34 @@ def _seed_text() -> str:
     return SEED_PATH.read_text()
 
 
+def _extract_balanced_block(text: str, start: int) -> str:
+    depth = 0
+    for index in range(start, len(text)):
+        char = text[index]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return text[start : index + 1]
+
+    raise AssertionError(f"could not find balanced block starting at offset {start}")
+
+
+def _find_seed_upsert_where_clauses() -> dict[str, str]:
+    text = _seed_text()
+    clauses: dict[str, str] = {}
+
+    for match in re.finditer(r"prisma\.(?P<model>\w+)\.upsert\(\{", text):
+        model = match.group("model")
+        call_body = _extract_balanced_block(text, match.end() - 1)
+        where_match = re.search(r"\bwhere:\s*\{", call_body)
+        assert where_match, f"prisma.{model}.upsert must declare a where clause"
+        clauses[model] = _extract_balanced_block(call_body, where_match.end() - 1)
+
+    return clauses
+
+
 def _package_version(package: str) -> str:
     pkg = json.loads(PACKAGE_JSON.read_text())
     spec = pkg.get("dependencies", {}).get(package) or pkg.get("devDependencies", {}).get(package)
@@ -77,20 +105,15 @@ def test_seed_upserts_tenant() -> None:
 
 
 def test_tenant_scoped_upserts_use_only_compound_unique_key_in_where() -> None:
-    text = _seed_text()
     expected_compound_keys = {
         "user": "tenantId_email",
         "client": "tenantId_phone",
     }
+    upsert_where_clauses = _find_seed_upsert_where_clauses()
 
     for model, compound_key in expected_compound_keys.items():
-        match = re.search(
-            rf"prisma\.{model}\.upsert\(\{{\s*where:\s*\{{(?P<where>.*?)\}}\s*,\s*update:",
-            text,
-            re.DOTALL,
-        )
-        assert match, f"prisma.{model}.upsert must declare a where clause"
-        where_clause = match.group("where")
+        where_clause = upsert_where_clauses.get(model)
+        assert where_clause, f"prisma.{model}.upsert must declare a where clause"
 
         assert re.search(
             rf"\b{compound_key}:\s*\{{\s*tenantId:\s*tenant\.id,",
@@ -105,6 +128,31 @@ def test_tenant_scoped_upserts_use_only_compound_unique_key_in_where() -> None:
             ),
             re.DOTALL,
         ), f"prisma.{model}.upsert must not include top-level tenantId in where"
+
+
+def test_all_seed_upserts_are_audited_for_tenant_scoping() -> None:
+    """Keep the seed upsert audit aligned with every upsert in prisma/seed.ts."""
+    expected_non_tenant_upserts = {"tenant"}
+    expected_tenant_scoped_upsert_keys = {
+        "user": "tenantId_email",
+        "client": "tenantId_phone",
+    }
+    audited_models = expected_non_tenant_upserts | set(expected_tenant_scoped_upsert_keys)
+    upsert_where_clauses = _find_seed_upsert_where_clauses()
+
+    assert set(upsert_where_clauses) == audited_models
+
+    for model, compound_key in expected_tenant_scoped_upsert_keys.items():
+        where_clause = upsert_where_clauses[model]
+        compound_key_match = re.search(rf"\b{compound_key}:\s*\{{", where_clause)
+        assert compound_key_match, f"prisma.{model}.upsert must use {compound_key}"
+
+        compound_key_block = _extract_balanced_block(where_clause, compound_key_match.end() - 1)
+        compound_key_end = compound_key_match.end() - 1 + len(compound_key_block)
+        remainder = where_clause[: compound_key_match.start()] + where_clause[compound_key_end:]
+        assert (
+            "tenantId:" not in remainder
+        ), f"prisma.{model}.upsert must not include tenantId outside {compound_key}"
 
 
 def test_seed_defines_exactly_three_services() -> None:

--- a/tests/test_prisma_seed.py
+++ b/tests/test_prisma_seed.py
@@ -76,14 +76,35 @@ def test_seed_upserts_tenant() -> None:
     assert "prisma.tenant.upsert" in text, "seed.ts must upsert the demo tenant"
 
 
-def test_tenant_scoped_upserts_have_top_level_tenant_id() -> None:
+def test_tenant_scoped_upserts_use_only_compound_unique_key_in_where() -> None:
     text = _seed_text()
-    for model in ("user", "client"):
-        assert re.search(
-            rf"prisma\.{model}\.upsert\(\{{\s*where:\s*\{{"
-            rf"\s*tenantId_\w+:\s*\{{\s*tenantId:\s*tenant\.id,",
+    expected_compound_keys = {
+        "user": "tenantId_email",
+        "client": "tenantId_phone",
+    }
+
+    for model, compound_key in expected_compound_keys.items():
+        match = re.search(
+            rf"prisma\.{model}\.upsert\(\{{\s*where:\s*\{{(?P<where>.*?)\}}\s*,\s*update:",
             text,
-        ), f"prisma.{model}.upsert must include a top-level tenantId in where"
+            re.DOTALL,
+        )
+        assert match, f"prisma.{model}.upsert must declare a where clause"
+        where_clause = match.group("where")
+
+        assert re.search(
+            rf"\b{compound_key}:\s*\{{\s*tenantId:\s*tenant\.id,",
+            where_clause,
+            re.DOTALL,
+        ), f"prisma.{model}.upsert must use the {compound_key} compound unique key"
+        assert not re.search(
+            r"(?:^|[,{]\s*)tenantId:\s*tenant\.id\s*,?\s*(?:$|[},])",
+            where_clause.replace(
+                re.search(rf"{compound_key}:\s*\{{.*?\}}", where_clause, re.DOTALL).group(0),
+                "",
+            ),
+            re.DOTALL,
+        ), f"prisma.{model}.upsert must not include top-level tenantId in where"
 
 
 def test_seed_defines_exactly_three_services() -> None:


### PR DESCRIPTION
<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
PR #160 addressed issue #158, but verification identified concerns (verdict: **CONCERNS**). This follow-up addresses the remaining gaps with improved task structure to ensure build artifact hygiene, proper tenant scoping in Prisma queries, and compliance with test requirements.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#160](https://github.com/iamkayleb/bukay/issues/160)
- [#158](https://github.com/iamkayleb/bukay/issues/158)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [x] Add the exact string 'tsconfig.tsbuildinfo' to .gitignore if it is not already present, and remove tsconfig.tsbuildinfo from version control if it exists.
  - [x] Define scope for: Add the exact string 'tsconfig.tsbuildinfo' to .gitignore if it is not already present (verify: config validated)
  - [x] Implement focused slice for: Add the exact string 'tsconfig.tsbuildinfo' to .gitignore if it is not already present (verify: config validated)
  - [x] Validate focused slice for: Add the exact string 'tsconfig.tsbuildinfo' to .gitignore if it is not already present (verify: config validated) remove tsconfig.tsbuildinfo from version control if it exists. (verify: config validated)
- [x] Update all upsert operations in prisma/seed.ts so that their where clauses use only the compound unique key (e.g., { tenantId_email: { tenantId, email } }) and do not include an extra top-level tenantId field.
  - [x] Define scope for: Update all upsert operations in prisma/seed.ts so that their where clauses use only the compound unique key (e.g. (verify: confirm completion in repo)
  - [x] Implement focused slice for: Update all upsert operations in prisma/seed.ts so that their where clauses use only the compound unique key (e.g. (verify: confirm completion in repo)
  - [x] Validate focused slice for: Update all upsert operations in prisma/seed.ts so that their where clauses use only the compound unique key (e.g. (verify: confirm completion in repo)
  - [x] { tenantId_email: { tenantId (verify: confirm completion in repo) email } }) (verify: confirm completion in repo)
  - [x] Define scope for: do not include an extra top-level tenantId field. (verify: confirm completion in repo)
  - [x] Implement focused slice for: do not include an extra top-level tenantId field. (verify: confirm completion in repo)
  - [x] Validate focused slice for: do not include an extra top-level tenantId field. (verify: confirm completion in repo)
- [x] Audit all Prisma queries in src/**/*.ts files and update any queries that lack tenant scoping to include tenantId in the where clause or use a compound unique key including tenantId.
  - [x] Define scope for: Audit all Prisma queries in src/**/*.ts files (verify: confirm completion in repo)
  - [x] Implement focused slice for: Audit all Prisma queries in src/**/*.ts files (verify: confirm completion in repo)
  - [x] Validate focused slice for: Audit all Prisma queries in src/**/*.ts files (verify: confirm completion in repo)
  - [x] Define scope for: update any queries that lack tenant scoping to include tenantId in the where clause or use a compound unique key including tenantId. (verify: confirm completion in repo)
  - [x] Implement focused slice for: update any queries that lack tenant scoping to include tenantId in the where clause or use a compound unique key including tenantId. (verify: confirm completion in repo)
  - [x] Validate focused slice for: update any queries that lack tenant scoping to include tenantId in the where clause or use a compound unique key including tenantId. (verify: confirm completion in repo)

#### Acceptance criteria
- [x] The exact string 'tsconfig.tsbuildinfo' appears as a standalone line in .gitignore, and the file tsconfig.tsbuildinfo does not exist in the repository (i.e., is not tracked by git).
- [x] In prisma/seed.ts, all Prisma upsert operations use a where clause containing only the compound unique key (e.g., { tenantId_email: { tenantId, email } }) and do not include a top-level tenantId field outside the compound key.
- [x] Every Prisma query in src/**/*.ts files includes tenant scoping: either a tenantId field in the where clause or uses a compound unique key that includes tenantId. No queries omit tenant scoping.

<!-- auto-status-summary:end -->

<details>

<summary>Full Issue Text</summary>



## Why

PR #160 addressed issue #158, but verification identified concerns (verdict: **CONCERNS**). This follow-up addresses the remaining gaps with improved task structure to ensure build artifact hygiene, proper tenant scoping in Prisma queries, and compliance with test requirements.

## Scope

_Not provided._

## Non-Goals

_Not provided._

## Tasks

- [x] Add the exact string 'tsconfig.tsbuildinfo' to .gitignore if it is not already present, and remove tsconfig.tsbuildinfo from version control if it exists.
  - [x] Define scope for: Add the exact string 'tsconfig.tsbuildinfo' to .gitignore if it is not already present (verify: config validated)
  - [x] Implement focused slice for: Add the exact string 'tsconfig.tsbuildinfo' to .gitignore if it is not already present (verify: config validated)
  - [x] Validate focused slice for: Add the exact string 'tsconfig.tsbuildinfo' to .gitignore if it is not already present (verify: config validated)
  - [x] remove tsconfig.tsbuildinfo from version control if it exists. (verify: config validated)
- [x] Update all upsert operations in prisma/seed.ts so that their where clauses use only the compound unique key (e.g., { tenantId_email: { tenantId, email } }) and do not include an extra top-level tenantId field.
  - [x] Define scope for: Update all upsert operations in prisma/seed.ts so that their where clauses use only the compound unique key (e.g. (verify: confirm completion in repo)
  - [x] Implement focused slice for: Update all upsert operations in prisma/seed.ts so that their where clauses use only the compound unique key (e.g. (verify: confirm completion in repo)
  - [x] Validate focused slice for: Update all upsert operations in prisma/seed.ts so that their where clauses use only the compound unique key (e.g. (verify: confirm completion in repo)
  - [x] { tenantId_email: { tenantId (verify: confirm completion in repo)
  - [x] email } }) (verify: confirm completion in repo)
  - [x] Define scope for: do not include an extra top-level tenantId field. (verify: confirm completion in repo)
  - [x] Implement focused slice for: do not include an extra top-level tenantId field. (verify: confirm completion in repo)
  - [x] Validate focused slice for: do not include an extra top-level tenantId field. (verify: confirm completion in repo)
- [x] Audit all Prisma queries in src/**/*.ts files and update any queries that lack tenant scoping to include tenantId in the where clause or use a compound unique key including tenantId.
  - [x] Define scope for: Audit all Prisma queries in src/**/*.ts files (verify: confirm completion in repo)
  - [x] Implement focused slice for: Audit all Prisma queries in src/**/*.ts files (verify: confirm completion in repo)
  - [x] Validate focused slice for: Audit all Prisma queries in src/**/*.ts files (verify: confirm completion in repo)
  - [x] Define scope for: update any queries that lack tenant scoping to include tenantId in the where clause or use a compound unique key including tenantId. (verify: confirm completion in repo)
  - [x] Implement focused slice for: update any queries that lack tenant scoping to include tenantId in the where clause or use a compound unique key including tenantId. (verify: confirm completion in repo)
  - [x] Validate focused slice for: update any queries that lack tenant scoping to include tenantId in the where clause or use a compound unique key including tenantId. (verify: confirm completion in repo)

## Acceptance Criteria

- [x] The exact string 'tsconfig.tsbuildinfo' appears as a standalone line in .gitignore, and the file tsconfig.tsbuildinfo does not exist in the repository (i.e., is not tracked by git).
- [x] In prisma/seed.ts, all Prisma upsert operations use a where clause containing only the compound unique key (e.g., { tenantId_email: { tenantId, email } }) and do not include a top-level tenantId field outside the compound key.
- [x] Every Prisma query in src/**/*.ts files includes tenant scoping: either a tenantId field in the where clause or uses a compound unique key that includes tenantId. No queries omit tenant scoping.

## Implementation Notes

For .gitignore, ensure 'tsconfig.tsbuildinfo' is present as a standalone line (not covered by a wildcard), and remove the file from git tracking if it exists.
In prisma/seed.ts, review all upsert operations and refactor their where clauses to use only the compound unique key, removing any top-level tenantId.
In src/**/*.ts, search for all Prisma queries and verify/update their where clauses to include tenantId or a compound unique key with tenantId.
Avoid using raw SQL for test schema setup; prefer Prisma migrations or schema introspection to ensure alignment with the actual schema.

<details>
<summary>Original Issue</summary>

```text
<!-- follow-up-depth: 2 -->
<!-- base-branch: eval/codex -->
## Why
PR #160 addressed issue #158, but verification identified concerns (verdict: **CONCERNS**). This follow-up addresses the remaining gaps with improved task structure to ensure build artifact hygiene, proper tenant scoping in Prisma queries, and compliance with test requirements.

## Source
- Original PR: #160
- Parent issue: #158

## Tasks
- [x] Add the exact string 'tsconfig.tsbuildinfo' to .gitignore if it is not already present, and remove tsconfig.tsbuildinfo from version control if it exists.
- [x] Update all upsert operations in prisma/seed.ts so that their where clauses use only the compound unique key (e.g., { tenantId_email: { tenantId, email } }) and do not include an extra top-level tenantId field.
- [x] Audit all Prisma queries in src/**/*.ts files and update any queries that lack tenant scoping to include tenantId in the where clause or use a compound unique key including tenantId.

## Acceptance Criteria
- [x] The exact string 'tsconfig.tsbuildinfo' appears as a standalone line in .gitignore, and the file tsconfig.tsbuildinfo does not exist in the repository (i.e., is not tracked by git).
- [x] In prisma/seed.ts, all Prisma upsert operations use a where clause containing only the compound unique key (e.g., { tenantId_email: { tenantId, email } }) and do not include a top-level tenantId field outside the compound key.
- [x] Every Prisma query in src/**/*.ts files includes tenant scoping: either a tenantId field in the where clause or uses a compound unique key that includes tenantId. No queries omit tenant scoping.

## Implementation Notes
- For .gitignore, ensure 'tsconfig.tsbuildinfo' is present as a standalone line (not covered by a wildcard), and remove the file from git tracking if it exists.
- In prisma/seed.ts, review all upsert operations and refactor their where clauses to use only the compound unique key, removing any top-level tenantId.
- In src/**/*.ts, search for all Prisma queries and verify/update their where clauses to include tenantId or a compound unique key with tenantId.
- Avoid using raw SQL for test schema setup; prefer Prisma migrations or schema introspection to ensure alignment with the actual schema.

## Notes
<details>
<summary>Advisory items (non-blocking)</summary>

- LLM evaluation could not run.

</details>

<details>
<summary>Background (previous attempt context)</summary>

- The tenantScoping test manually creates a SQLite schema with raw SQL instead of using Prisma migrations. This approach can drift from the actual Prisma schema if the schema evolves, making tests brittle. Use Prisma migrations or schema introspection to set up the test database schema, ensuring alignment with the actual schema.
- The test for .gitignore checks for the exact string 'tsconfig.tsbuildinfo', but only a wildcard (*.tsbuildinfo) was present. The test fails if the exact string is not present, even if the wildcard covers the file. Add the exact string 'tsconfig.tsbuildinfo' to .gitignore.

</details>
```
</details>



</details>

—
PR created automatically to engage Codex.

<!-- pr-preamble:start -->
> **Source:** Issue #164

<!-- pr-preamble:end -->


