### PR TITLE
Codex bootstrap for #168

### DIFF
--- a/__tests__/app/api/auth/auth-flow.test.ts
+++ b/__tests__/app/api/auth/auth-flow.test.ts
@@ -12,8 +12,10 @@ import {
   OTP_MAX_REQUESTS_PER_WINDOW,
   OTP_RESEND_COOLDOWN_MS,
   OTP_TTL_MS,
+  MemoryOtpStateStore,
   __resetOtpStoreForTests,
   getOtpStore,
+  setOtpStateStoreForTests,
 } from "@/app/lib/auth/otp";
 import { SESSION_COOKIE_NAME, SESSION_TTL_MS, signSession } from "@/app/lib/auth/session";
 
@@ -46,6 +48,7 @@ beforeEach(() => {
   vi.useRealTimers();
   process.env.SESSION_SECRET = "test-secret-must-be-long-enough";
   __resetOtpStoreForTests();
+  setOtpStateStoreForTests(new MemoryOtpStateStore());
   __resetSmsProviderForTests();
   sms = new MemorySmsProvider();
   setSmsProviderForTests(sms);
@@ -139,7 +142,8 @@ describe("end-to-end auth flow", () => {
     );
     expect(second.status).toBe(401);
     const body = await second.json();
-    expect(body.error).toBe("not_found");
+    expect(body.error).toBe("used");
+    expect(body.message).toBe("OTP already used");
   });
 
   it("applies resend cooldown between consecutive OTP requests", async () => {

--- a/__tests__/app/api/auth/auth-flow.test.ts
+++ b/__tests__/app/api/auth/auth-flow.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { NextRequest } from "next/server";
 
 import { POST as login } from "@/app/api/auth/login/route";
@@ -8,7 +8,7 @@ import { GET as me } from "@/app/api/auth/me/route";
 
 import { MemorySmsProvider } from "@/app/lib/sms/memory";
 import { __resetSmsProviderForTests, setSmsProviderForTests } from "@/app/lib/auth/sms";
-import { __resetOtpStoreForTests, getOtpStore } from "@/app/lib/auth/otp";
+import { OTP_TTL_MS, __resetOtpStoreForTests, getOtpStore } from "@/app/lib/auth/otp";
 import { SESSION_COOKIE_NAME } from "@/app/lib/auth/session";
 
 function jsonRequest(url: string, body: unknown, init?: { cookie?: string }): NextRequest {
@@ -37,11 +37,16 @@ const PHONE_E164 = "+2348031234567";
 let sms: MemorySmsProvider;
 
 beforeEach(() => {
+  vi.useRealTimers();
   process.env.SESSION_SECRET = "test-secret-must-be-long-enough";
   __resetOtpStoreForTests();
   __resetSmsProviderForTests();
   sms = new MemorySmsProvider();
   setSmsProviderForTests(sms);
+});
+
+afterEach(() => {
+  vi.useRealTimers();
 });
 
 describe("end-to-end auth flow", () => {
@@ -93,6 +98,25 @@ describe("end-to-end auth flow", () => {
     const body = await res.json();
     expect(body.ok).toBe(false);
     expect(body.error).toBe("mismatch");
+  });
+
+  it("rejects an expired OTP with an explicit expiration message", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+
+    await login(jsonRequest("http://test/api/auth/login", { phone: PHONE_LOCAL }));
+    const code = extractCode(sms.lastTo(PHONE_E164)!.body);
+
+    vi.advanceTimersByTime(OTP_TTL_MS + 1);
+
+    const res = await verify(
+      jsonRequest("http://test/api/auth/verify", { phone: PHONE_LOCAL, code })
+    );
+    expect([400, 401]).toContain(res.status);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error).toBe("expired");
+    expect(body.message).toBe("OTP expired");
   });
 
   it("rejects a used OTP on second verify", async () => {

--- a/__tests__/app/api/auth/auth-flow.test.ts
+++ b/__tests__/app/api/auth/auth-flow.test.ts
@@ -8,7 +8,13 @@ import { GET as me } from "@/app/api/auth/me/route";
 
 import { MemorySmsProvider } from "@/app/lib/sms/memory";
 import { __resetSmsProviderForTests, setSmsProviderForTests } from "@/app/lib/auth/sms";
-import { OTP_TTL_MS, __resetOtpStoreForTests, getOtpStore } from "@/app/lib/auth/otp";
+import {
+  OTP_MAX_REQUESTS_PER_WINDOW,
+  OTP_RESEND_COOLDOWN_MS,
+  OTP_TTL_MS,
+  __resetOtpStoreForTests,
+  getOtpStore,
+} from "@/app/lib/auth/otp";
 import { SESSION_COOKIE_NAME } from "@/app/lib/auth/session";
 
 function jsonRequest(url: string, body: unknown, init?: { cookie?: string }): NextRequest {
@@ -136,7 +142,7 @@ describe("end-to-end auth flow", () => {
     expect(body.error).toBe("not_found");
   });
 
-  it("rate-limits brute-force OTP requests", async () => {
+  it("applies resend cooldown between consecutive OTP requests", async () => {
     // First /login is fine; subsequent rapid logins should hit cooldown -> 429
     const first = await login(jsonRequest("http://test/api/auth/login", { phone: PHONE_LOCAL }));
     expect(first.status).toBe(200);
@@ -146,6 +152,25 @@ describe("end-to-end auth flow", () => {
     expect(second.headers.get("retry-after")).toMatch(/^\d+$/);
     const body = await second.json();
     expect(body.error).toBe("cooldown");
+  });
+
+  it("rejects OTP requests beyond the configured rate-limit window", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+
+    for (let i = 0; i < OTP_MAX_REQUESTS_PER_WINDOW; i++) {
+      const res = await login(jsonRequest("http://test/api/auth/login", { phone: PHONE_LOCAL }));
+      expect(res.status).toBe(200);
+      vi.advanceTimersByTime(OTP_RESEND_COOLDOWN_MS + 1);
+    }
+
+    const blocked = await login(jsonRequest("http://test/api/auth/login", { phone: PHONE_LOCAL }));
+    expect(blocked.status).toBe(429);
+    expect(blocked.headers.get("retry-after")).toMatch(/^\d+$/);
+    const body = await blocked.json();
+    expect(body.ok).toBe(false);
+    expect(body.error).toBe("rate_limited");
+    expect(body.message).toBe("rate limit exceeded");
   });
 
   it("rejects an invalid phone number", async () => {

--- a/__tests__/app/api/auth/auth-flow.test.ts
+++ b/__tests__/app/api/auth/auth-flow.test.ts
@@ -15,7 +15,7 @@ import {
   __resetOtpStoreForTests,
   getOtpStore,
 } from "@/app/lib/auth/otp";
-import { SESSION_COOKIE_NAME } from "@/app/lib/auth/session";
+import { SESSION_COOKIE_NAME, SESSION_TTL_MS, signSession } from "@/app/lib/auth/session";
 
 function jsonRequest(url: string, body: unknown, init?: { cookie?: string }): NextRequest {
   const headers: Record<string, string> = { "content-type": "application/json" };
@@ -191,6 +191,53 @@ describe("end-to-end auth flow", () => {
   it("/me returns 401 with no cookie", async () => {
     const res = await me(new NextRequest("http://test/api/auth/me"));
     expect(res.status).toBe(401);
+  });
+
+  it("rejects an expired session cookie with an explicit expiration message", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-01-01T00:00:00.000Z"));
+    const now = Date.now();
+    const token = signSession({
+      sub: `user:${PHONE_E164}`,
+      phone: PHONE_E164,
+      iat: now - SESSION_TTL_MS,
+      exp: now - 1,
+    });
+
+    const res = await me(
+      new NextRequest("http://test/api/auth/me", {
+        headers: { cookie: `${SESSION_COOKIE_NAME}=${token}` },
+      })
+    );
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error).toBe("session_expired");
+    expect(body.message).toBe("session expired");
+  });
+
+  it("rejects a tampered session cookie with an explicit invalid-session message", async () => {
+    const now = Date.now();
+    const token = signSession({
+      sub: `user:${PHONE_E164}`,
+      phone: PHONE_E164,
+      iat: now,
+      exp: now + SESSION_TTL_MS,
+    });
+    const tampered = `${token.slice(0, -1)}${token.endsWith("a") ? "b" : "a"}`;
+
+    const res = await me(
+      new NextRequest("http://test/api/auth/me", {
+        headers: { cookie: `${SESSION_COOKIE_NAME}=${tampered}` },
+      })
+    );
+
+    expect(res.status).toBe(401);
+    const body = await res.json();
+    expect(body.ok).toBe(false);
+    expect(body.error).toBe("session_invalid");
+    expect(body.message).toBe("session invalid");
   });
 
   it("normalizes 234-prefixed phone the same as 0-prefixed", async () => {

--- a/__tests__/app/lib/auth/otp.test.ts
+++ b/__tests__/app/lib/auth/otp.test.ts
@@ -4,6 +4,7 @@ import {
   OTP_MAX_VERIFY_ATTEMPTS,
   OTP_RESEND_COOLDOWN_MS,
   OTP_TTL_MS,
+  MemoryOtpStateStore,
   OtpStore,
 } from "@/app/lib/auth/otp";
 
@@ -20,85 +21,117 @@ class FakeClock {
 const PHONE = "+2348031234567";
 
 describe("OtpStore", () => {
-  it("issues a 6-digit code and verifies it once", () => {
-    const clock = new FakeClock();
-    const store = new OtpStore(clock);
+  function store(clock = new FakeClock(), state = new MemoryOtpStateStore()) {
+    return new OtpStore(clock, state);
+  }
 
-    const issued = store.issue(PHONE);
+  it("issues a 6-digit code and verifies it once", async () => {
+    const clock = new FakeClock();
+    const otpStore = store(clock);
+
+    const issued = await otpStore.issue(PHONE);
     if (!issued.ok) throw new Error("expected ok");
     expect(issued.code).toMatch(/^\d{6}$/);
     expect(issued.expiresAt).toBe(clock.now() + OTP_TTL_MS);
 
-    expect(store.verify(PHONE, issued.code).ok).toBe(true);
-    // second use rejected — record was consumed/cleared
-    expect(store.verify(PHONE, issued.code).ok).toBe(false);
+    expect((await otpStore.verify(PHONE, issued.code)).ok).toBe(true);
+    expect(await otpStore.verify(PHONE, issued.code)).toEqual({ ok: false, reason: "used" });
   });
 
-  it("rejects a mismatched code", () => {
-    const store = new OtpStore(new FakeClock());
-    store.issue(PHONE);
-    const r = store.verify(PHONE, "000000");
+  it("rejects a mismatched code", async () => {
+    const otpStore = store();
+    await otpStore.issue(PHONE);
+    const r = await otpStore.verify(PHONE, "000000");
     expect(r).toEqual({ ok: false, reason: "mismatch" });
   });
 
-  it("rejects an expired code after 5 minutes", () => {
+  it("rejects an expired code after 5 minutes", async () => {
     const clock = new FakeClock();
-    const store = new OtpStore(clock);
-    const issued = store.issue(PHONE);
+    const otpStore = store(clock);
+    const issued = await otpStore.issue(PHONE);
     if (!issued.ok) throw new Error("expected ok");
     clock.advance(OTP_TTL_MS + 1);
-    expect(store.verify(PHONE, issued.code)).toEqual({ ok: false, reason: "expired" });
+    expect(await otpStore.verify(PHONE, issued.code)).toEqual({ ok: false, reason: "expired" });
   });
 
-  it("locks out after too many verify attempts", () => {
-    const store = new OtpStore(new FakeClock());
-    store.issue(PHONE);
+  it("locks out after too many verify attempts", async () => {
+    const otpStore = store();
+    await otpStore.issue(PHONE);
     for (let i = 0; i < OTP_MAX_VERIFY_ATTEMPTS; i++) {
-      expect(store.verify(PHONE, "000000").ok).toBe(false);
+      expect((await otpStore.verify(PHONE, "000000")).ok).toBe(false);
     }
-    expect(store.verify(PHONE, "000000")).toEqual({
+    expect(await otpStore.verify(PHONE, "000000")).toEqual({
       ok: false,
       reason: "too_many_attempts",
     });
   });
 
-  it("enforces resend cooldown between consecutive issue calls", () => {
+  it("enforces resend cooldown between consecutive issue calls", async () => {
     const clock = new FakeClock();
-    const store = new OtpStore(clock);
-    expect(store.issue(PHONE).ok).toBe(true);
-    const second = store.issue(PHONE);
+    const otpStore = store(clock);
+    expect((await otpStore.issue(PHONE)).ok).toBe(true);
+    const second = await otpStore.issue(PHONE);
     expect(second.ok).toBe(false);
     if (second.ok) throw new Error("unreachable");
     expect(second.reason).toBe("cooldown");
   });
 
-  it("allows reissue after cooldown elapses", () => {
+  it("allows reissue after cooldown elapses", async () => {
     const clock = new FakeClock();
-    const store = new OtpStore(clock);
-    expect(store.issue(PHONE).ok).toBe(true);
+    const otpStore = store(clock);
+    expect((await otpStore.issue(PHONE)).ok).toBe(true);
     clock.advance(OTP_RESEND_COOLDOWN_MS + 1);
-    expect(store.issue(PHONE).ok).toBe(true);
+    expect((await otpStore.issue(PHONE)).ok).toBe(true);
   });
 
-  it("rate-limits issue calls within the window", () => {
+  it("rate-limits issue calls within the window", async () => {
     const clock = new FakeClock();
-    const store = new OtpStore(clock);
+    const otpStore = store(clock);
 
     for (let i = 0; i < OTP_MAX_REQUESTS_PER_WINDOW; i++) {
-      const r = store.issue(PHONE);
+      const r = await otpStore.issue(PHONE);
       expect(r.ok).toBe(true);
       clock.advance(OTP_RESEND_COOLDOWN_MS + 1);
     }
-    const blocked = store.issue(PHONE);
+    const blocked = await otpStore.issue(PHONE);
     expect(blocked.ok).toBe(false);
     if (blocked.ok) throw new Error("unreachable");
     expect(blocked.reason).toBe("rate_limited");
   });
 
-  it("isolates rate limit by phone number", () => {
+  it("isolates rate limit by phone number", async () => {
     const clock = new FakeClock();
-    const store = new OtpStore(clock);
-    expect(store.issue(PHONE).ok).toBe(true);
-    expect(store.issue("+2348099999999").ok).toBe(true);
+    const otpStore = store(clock);
+    expect((await otpStore.issue(PHONE)).ok).toBe(true);
+    expect((await otpStore.issue("+2348099999999")).ok).toBe(true);
+  });
+
+  it("shares OTP codes and rate limits across store instances using the same state store", async () => {
+    const clock = new FakeClock();
+    const state = new MemoryOtpStateStore();
+    const instanceA = store(clock, state);
+    const instanceB = store(clock, state);
+
+    const issued = await instanceA.issue(PHONE);
+    if (!issued.ok) throw new Error("expected ok");
+
+    expect(await instanceB.verify(PHONE, issued.code)).toEqual({ ok: true });
+    expect(await instanceA.verify(PHONE, issued.code)).toEqual({ ok: false, reason: "used" });
+  });
+
+  it("persists rate-limit counters across store instances using the same state store", async () => {
+    const clock = new FakeClock();
+    const state = new MemoryOtpStateStore();
+
+    for (let i = 0; i < OTP_MAX_REQUESTS_PER_WINDOW; i++) {
+      const issued = await store(clock, state).issue(PHONE);
+      expect(issued.ok).toBe(true);
+      clock.advance(OTP_RESEND_COOLDOWN_MS + 1);
+    }
+
+    const blocked = await store(clock, state).issue(PHONE);
+    expect(blocked.ok).toBe(false);
+    if (blocked.ok) throw new Error("unreachable");
+    expect(blocked.reason).toBe("rate_limited");
   });
 });

--- a/__tests__/app/lib/auth/otp.test.ts
+++ b/__tests__/app/lib/auth/otp.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { afterEach, describe, it, expect, vi } from "vitest";
 import {
   OTP_MAX_REQUESTS_PER_WINDOW,
   OTP_MAX_VERIFY_ATTEMPTS,
@@ -19,6 +19,10 @@ class FakeClock {
 }
 
 const PHONE = "+2348031234567";
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
 
 describe("OtpStore", () => {
   function store(clock = new FakeClock(), state = new MemoryOtpStateStore()) {
@@ -43,6 +47,16 @@ describe("OtpStore", () => {
     await otpStore.issue(PHONE);
     const r = await otpStore.verify(PHONE, "000000");
     expect(r).toEqual({ ok: false, reason: "mismatch" });
+  });
+
+  it("binds OTP verification to the configured OTP_SECRET", async () => {
+    vi.stubEnv("OTP_SECRET", "first-test-otp-secret");
+    const otpStore = store();
+    const issued = await otpStore.issue(PHONE);
+    if (!issued.ok) throw new Error("expected ok");
+
+    vi.stubEnv("OTP_SECRET", "second-test-otp-secret");
+    expect(await otpStore.verify(PHONE, issued.code)).toEqual({ ok: false, reason: "mismatch" });
   });
 
   it("rejects an expired code after 5 minutes", async () => {
@@ -133,5 +147,25 @@ describe("OtpStore", () => {
     expect(blocked.ok).toBe(false);
     if (blocked.ok) throw new Error("unreachable");
     expect(blocked.reason).toBe("rate_limited");
+  });
+});
+
+describe("OTP_SECRET configuration", () => {
+  it("fails module startup in production when OTP_SECRET is missing", async () => {
+    vi.resetModules();
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("OTP_SECRET", "");
+
+    await expect(import("@/app/lib/auth/otp")).rejects.toThrow(
+      "OTP_SECRET must be set in production to sign OTP codes"
+    );
+  });
+
+  it("allows module startup in production when OTP_SECRET is set", async () => {
+    vi.resetModules();
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("OTP_SECRET", "production-test-otp-secret");
+
+    await expect(import("@/app/lib/auth/otp")).resolves.toHaveProperty("OtpStore");
   });
 });

--- a/agents/codex-168.md
+++ b/agents/codex-168.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for codex on issue #168 -->

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -32,8 +32,10 @@ export async function POST(req: NextRequest) {
   const result = getOtpStore().issue(phone);
   if (!result.ok) {
     const retryAfter = Math.max(1, Math.ceil(result.retryAfterMs / 1000));
+    const message =
+      result.reason === "rate_limited" ? "rate limit exceeded" : "OTP cooldown active";
     return NextResponse.json(
-      { ok: false, error: result.reason, retryAfterSeconds: retryAfter },
+      { ok: false, error: result.reason, message, retryAfterSeconds: retryAfter },
       { status: 429, headers: { "Retry-After": String(retryAfter) } }
     );
   }

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -29,7 +29,7 @@ export async function POST(req: NextRequest) {
     throw err;
   }
 
-  const result = getOtpStore().issue(phone);
+  const result = await getOtpStore().issue(phone);
   if (!result.ok) {
     const retryAfter = Math.max(1, Math.ceil(result.retryAfterMs / 1000));
     const message =

--- a/app/api/auth/me/route.ts
+++ b/app/api/auth/me/route.ts
@@ -4,18 +4,27 @@ import {
   buildSessionCookie,
   readSessionTokenFromCookieHeader,
   signSession,
-  verifySession,
+  verifySessionDetailed,
 } from "@/app/lib/auth/session";
 
 export const dynamic = "force-dynamic";
 
 export async function GET(req: NextRequest) {
   const token = readSessionTokenFromCookieHeader(req.headers.get("cookie"));
-  const session = token ? verifySession(token) : null;
-  if (!session) {
-    return NextResponse.json({ ok: false, error: "unauthenticated" }, { status: 401 });
+  const result = verifySessionDetailed(token);
+  if (!result.ok) {
+    const message = result.reason === "expired" ? "session expired" : "session invalid";
+    return NextResponse.json(
+      {
+        ok: false,
+        error: result.reason === "expired" ? "session_expired" : "session_invalid",
+        message,
+      },
+      { status: 401 }
+    );
   }
 
+  const session = result.payload;
   const now = Date.now();
   const refreshed = signSession({ ...session, iat: now, exp: now + SESSION_TTL_MS });
   const res = NextResponse.json({

--- a/app/api/auth/verify/route.ts
+++ b/app/api/auth/verify/route.ts
@@ -40,6 +40,13 @@ export async function POST(req: NextRequest) {
 
   const result = getOtpStore().verify(phone, code);
   if (!result.ok) {
+    if (result.reason === "expired") {
+      return NextResponse.json(
+        { ok: false, error: result.reason, message: "OTP expired" },
+        { status: 401 }
+      );
+    }
+
     const status = result.reason === "mismatch" || result.reason === "not_found" ? 401 : 410;
     return NextResponse.json({ ok: false, error: result.reason }, { status });
   }

--- a/app/api/auth/verify/route.ts
+++ b/app/api/auth/verify/route.ts
@@ -38,11 +38,17 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ ok: false, error: "invalid_code_format" }, { status: 400 });
   }
 
-  const result = getOtpStore().verify(phone, code);
+  const result = await getOtpStore().verify(phone, code);
   if (!result.ok) {
     if (result.reason === "expired") {
       return NextResponse.json(
         { ok: false, error: result.reason, message: "OTP expired" },
+        { status: 401 }
+      );
+    }
+    if (result.reason === "used") {
+      return NextResponse.json(
+        { ok: false, error: result.reason, message: "OTP already used" },
         { status: 401 }
       );
     }

--- a/app/lib/auth/otp.ts
+++ b/app/lib/auth/otp.ts
@@ -1,4 +1,4 @@
-import { createHash, randomInt } from "node:crypto";
+import { createHmac, randomInt } from "node:crypto";
 import { prisma } from "@/app/db/prisma";
 
 export const OTP_TTL_MS = 5 * 60 * 1000;
@@ -28,8 +28,21 @@ export type VerifyResult =
   | { ok: true }
   | { ok: false; reason: "not_found" | "expired" | "used" | "mismatch" | "too_many_attempts" };
 
+const DEVELOPMENT_OTP_SECRET = "development-only-otp-secret";
+
+export function getOtpSecret(): string {
+  const secret = process.env.OTP_SECRET;
+  if (secret) return secret;
+  if (process.env.NODE_ENV === "production") {
+    throw new Error("OTP_SECRET must be set in production to sign OTP codes");
+  }
+  return DEVELOPMENT_OTP_SECRET;
+}
+
+getOtpSecret();
+
 function hashCode(phone: string, code: string): string {
-  return createHash("sha256").update(`${phone}:${code}`).digest("hex");
+  return createHmac("sha256", getOtpSecret()).update(`${phone}:${code}`).digest("hex");
 }
 
 function generateCode(): string {

--- a/app/lib/auth/otp.ts
+++ b/app/lib/auth/otp.ts
@@ -1,4 +1,5 @@
 import { createHash, randomInt } from "node:crypto";
+import { prisma } from "@/app/db/prisma";
 
 export const OTP_TTL_MS = 5 * 60 * 1000;
 export const OTP_RESEND_COOLDOWN_MS = 30 * 1000;
@@ -6,14 +7,14 @@ export const OTP_MAX_REQUESTS_PER_WINDOW = 5;
 export const OTP_RATE_WINDOW_MS = 15 * 60 * 1000;
 export const OTP_MAX_VERIFY_ATTEMPTS = 5;
 
-type OtpRecord = {
+export type OtpRecord = {
   hash: string;
   expiresAt: number;
   attempts: number;
   consumed: boolean;
 };
 
-type RateRecord = {
+export type RateRecord = {
   windowStart: number;
   count: number;
   lastSentAt: number;
@@ -41,18 +42,181 @@ export interface Clock {
 
 const defaultClock: Clock = { now: () => Date.now() };
 
-export class OtpStore {
-  private readonly codes = new Map<string, OtpRecord>();
-  private readonly rate = new Map<string, RateRecord>();
-  private readonly clock: Clock;
+export interface OtpStateStore {
+  getCode(phone: string): Promise<OtpRecord | null>;
+  setCode(phone: string, record: OtpRecord): Promise<void>;
+  updateCode(phone: string, record: OtpRecord): Promise<void>;
+  deleteCode(phone: string): Promise<void>;
+  getRate(phone: string): Promise<RateRecord | null>;
+  setRate(phone: string, record: RateRecord): Promise<void>;
+  clear(): Promise<void>;
+}
 
-  constructor(clock: Clock = defaultClock) {
-    this.clock = clock;
+type PrismaOtpClient = {
+  otpCode: {
+    findUnique(args: { where: { phone: string } }): Promise<{
+      hash: string;
+      expiresAt: Date;
+      attempts: number;
+      consumed: boolean;
+    } | null>;
+    upsert(args: {
+      where: { phone: string };
+      create: {
+        phone: string;
+        hash: string;
+        expiresAt: Date;
+        attempts: number;
+        consumed: boolean;
+      };
+      update: {
+        hash?: string;
+        expiresAt?: Date;
+        attempts?: number;
+        consumed?: boolean;
+      };
+    }): Promise<unknown>;
+    deleteMany(args?: { where?: { phone?: string } }): Promise<unknown>;
+  };
+  otpRateLimit: {
+    findUnique(args: { where: { phone: string } }): Promise<{
+      windowStart: Date;
+      count: number;
+      lastSentAt: Date;
+    } | null>;
+    upsert(args: {
+      where: { phone: string };
+      create: { phone: string; windowStart: Date; count: number; lastSentAt: Date };
+      update: { windowStart?: Date; count?: number; lastSentAt?: Date };
+    }): Promise<unknown>;
+    deleteMany(args?: { where?: { phone?: string } }): Promise<unknown>;
+  };
+};
+
+export class PrismaOtpStateStore implements OtpStateStore {
+  constructor(private readonly client: PrismaOtpClient = prisma as unknown as PrismaOtpClient) {}
+
+  async getCode(phone: string): Promise<OtpRecord | null> {
+    const record = await this.client.otpCode.findUnique({ where: { phone } });
+    if (!record) return null;
+
+    return {
+      hash: record.hash,
+      expiresAt: record.expiresAt.getTime(),
+      attempts: record.attempts,
+      consumed: record.consumed,
+    };
   }
 
-  issue(phone: string): IssueResult {
+  async setCode(phone: string, record: OtpRecord): Promise<void> {
+    await this.client.otpCode.upsert({
+      where: { phone },
+      create: {
+        phone,
+        hash: record.hash,
+        expiresAt: new Date(record.expiresAt),
+        attempts: record.attempts,
+        consumed: record.consumed,
+      },
+      update: {
+        hash: record.hash,
+        expiresAt: new Date(record.expiresAt),
+        attempts: record.attempts,
+        consumed: record.consumed,
+      },
+    });
+  }
+
+  async updateCode(phone: string, record: OtpRecord): Promise<void> {
+    await this.setCode(phone, record);
+  }
+
+  async deleteCode(phone: string): Promise<void> {
+    await this.client.otpCode.deleteMany({ where: { phone } });
+  }
+
+  async getRate(phone: string): Promise<RateRecord | null> {
+    const record = await this.client.otpRateLimit.findUnique({ where: { phone } });
+    if (!record) return null;
+
+    return {
+      windowStart: record.windowStart.getTime(),
+      count: record.count,
+      lastSentAt: record.lastSentAt.getTime(),
+    };
+  }
+
+  async setRate(phone: string, record: RateRecord): Promise<void> {
+    await this.client.otpRateLimit.upsert({
+      where: { phone },
+      create: {
+        phone,
+        windowStart: new Date(record.windowStart),
+        count: record.count,
+        lastSentAt: new Date(record.lastSentAt),
+      },
+      update: {
+        windowStart: new Date(record.windowStart),
+        count: record.count,
+        lastSentAt: new Date(record.lastSentAt),
+      },
+    });
+  }
+
+  async clear(): Promise<void> {
+    await this.client.otpCode.deleteMany();
+    await this.client.otpRateLimit.deleteMany();
+  }
+}
+
+export class MemoryOtpStateStore implements OtpStateStore {
+  private readonly codes = new Map<string, OtpRecord>();
+  private readonly rate = new Map<string, RateRecord>();
+
+  async getCode(phone: string): Promise<OtpRecord | null> {
+    const record = this.codes.get(phone);
+    return record ? { ...record } : null;
+  }
+
+  async setCode(phone: string, record: OtpRecord): Promise<void> {
+    this.codes.set(phone, { ...record });
+  }
+
+  async updateCode(phone: string, record: OtpRecord): Promise<void> {
+    await this.setCode(phone, record);
+  }
+
+  async deleteCode(phone: string): Promise<void> {
+    this.codes.delete(phone);
+  }
+
+  async getRate(phone: string): Promise<RateRecord | null> {
+    const record = this.rate.get(phone);
+    return record ? { ...record } : null;
+  }
+
+  async setRate(phone: string, record: RateRecord): Promise<void> {
+    this.rate.set(phone, { ...record });
+  }
+
+  async clear(): Promise<void> {
+    this.codes.clear();
+    this.rate.clear();
+  }
+}
+
+export class OtpStore {
+  private readonly clock: Clock;
+  private readonly state: OtpStateStore;
+
+  constructor(clock: Clock = defaultClock, state: OtpStateStore = new PrismaOtpStateStore()) {
+    this.clock = clock;
+    this.state = state;
+  }
+
+  async issue(phone: string): Promise<IssueResult> {
     const now = this.clock.now();
-    const rate = this.rate.get(phone);
+    const rate = await this.state.getRate(phone);
 
     if (rate) {
       if (now - rate.windowStart >= OTP_RATE_WINDOW_MS) {
@@ -76,7 +240,7 @@ export class OtpStore {
     }
 
     const code = generateCode();
-    this.codes.set(phone, {
+    await this.state.setCode(phone, {
       hash: hashCode(phone, code),
       expiresAt: now + OTP_TTL_MS,
       attempts: 0,
@@ -86,50 +250,58 @@ export class OtpStore {
     if (rate) {
       rate.count += 1;
       rate.lastSentAt = now;
+      await this.state.setRate(phone, rate);
     } else {
-      this.rate.set(phone, { windowStart: now, count: 1, lastSentAt: now });
+      await this.state.setRate(phone, { windowStart: now, count: 1, lastSentAt: now });
     }
 
     return { ok: true, code, expiresAt: now + OTP_TTL_MS };
   }
 
-  verify(phone: string, code: string): VerifyResult {
+  async verify(phone: string, code: string): Promise<VerifyResult> {
     const now = this.clock.now();
-    const record = this.codes.get(phone);
+    const record = await this.state.getCode(phone);
     if (!record) return { ok: false, reason: "not_found" };
     if (record.consumed) return { ok: false, reason: "used" };
     if (now >= record.expiresAt) {
-      this.codes.delete(phone);
+      await this.state.deleteCode(phone);
       return { ok: false, reason: "expired" };
     }
     if (record.attempts >= OTP_MAX_VERIFY_ATTEMPTS) {
-      this.codes.delete(phone);
+      await this.state.deleteCode(phone);
       return { ok: false, reason: "too_many_attempts" };
     }
 
     record.attempts += 1;
     if (hashCode(phone, code) !== record.hash) {
+      await this.state.updateCode(phone, record);
       return { ok: false, reason: "mismatch" };
     }
 
     record.consumed = true;
-    this.codes.delete(phone);
+    await this.state.updateCode(phone, record);
     return { ok: true };
   }
 
-  reset(): void {
-    this.codes.clear();
-    this.rate.clear();
+  async reset(): Promise<void> {
+    await this.state.clear();
   }
 }
 
 let singleton: OtpStore | null = null;
+let stateStoreOverride: OtpStateStore | null = null;
 
 export function getOtpStore(): OtpStore {
-  if (!singleton) singleton = new OtpStore();
+  if (!singleton) singleton = new OtpStore(defaultClock, stateStoreOverride ?? undefined);
   return singleton;
 }
 
 export function __resetOtpStoreForTests(): void {
+  singleton = null;
+  stateStoreOverride = null;
+}
+
+export function setOtpStateStoreForTests(state: OtpStateStore): void {
+  stateStoreOverride = state;
   singleton = null;
 }

--- a/app/lib/auth/session.ts
+++ b/app/lib/auth/session.ts
@@ -10,6 +10,9 @@ export type SessionPayload = {
   exp: number;
 };
 
+export type SessionVerificationResult =
+  { ok: true; payload: SessionPayload } | { ok: false; reason: "missing" | "invalid" | "expired" };
+
 function b64urlEncode(buf: Buffer): string {
   return buf.toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
 }
@@ -34,9 +37,17 @@ export function signSession(payload: SessionPayload, secret?: string): string {
 }
 
 export function verifySession(token: string, secret?: string): SessionPayload | null {
-  if (!token || typeof token !== "string") return null;
+  const result = verifySessionDetailed(token, secret);
+  return result.ok ? result.payload : null;
+}
+
+export function verifySessionDetailed(
+  token: string | null | undefined,
+  secret?: string
+): SessionVerificationResult {
+  if (!token || typeof token !== "string") return { ok: false, reason: "missing" };
   const dot = token.indexOf(".");
-  if (dot <= 0) return null;
+  if (dot <= 0) return { ok: false, reason: "invalid" };
   const body = token.slice(0, dot);
   const sigPart = token.slice(dot + 1);
 
@@ -46,20 +57,22 @@ export function verifySession(token: string, secret?: string): SessionPayload | 
     expected = createHmac("sha256", getSecret(secret)).update(body).digest();
     provided = b64urlDecode(sigPart);
   } catch {
-    return null;
+    return { ok: false, reason: "invalid" };
   }
-  if (expected.length !== provided.length) return null;
-  if (!timingSafeEqual(expected, provided)) return null;
+  if (expected.length !== provided.length) return { ok: false, reason: "invalid" };
+  if (!timingSafeEqual(expected, provided)) return { ok: false, reason: "invalid" };
 
   let payload: SessionPayload;
   try {
     payload = JSON.parse(b64urlDecode(body).toString("utf8")) as SessionPayload;
   } catch {
-    return null;
+    return { ok: false, reason: "invalid" };
   }
-  if (!payload || typeof payload.sub !== "string" || typeof payload.exp !== "number") return null;
-  if (Date.now() >= payload.exp) return null;
-  return payload;
+  if (!payload || typeof payload.sub !== "string" || typeof payload.exp !== "number") {
+    return { ok: false, reason: "invalid" };
+  }
+  if (Date.now() >= payload.exp) return { ok: false, reason: "expired" };
+  return { ok: true, payload };
 }
 
 export type CookieAttrs = {

--- a/docs/DATA_MODEL.md
+++ b/docs/DATA_MODEL.md
@@ -28,6 +28,13 @@ The tenant-owned models are:
 cascades to its owned rows through the Prisma relations. `Booking` restricts deletion of referenced
 clients and services, and sets `staffId` to null when a referenced staff row is deleted.
 
+Authentication state is stored in shared non-tenant-scoped tables:
+
+| Model | Purpose | Constraints and indexes |
+|-------|---------|-------------------------|
+| `OtpCode` | Pending or consumed one-time login codes keyed by phone | `phone` primary key, `@@index([expiresAt])` |
+| `OtpRateLimit` | OTP request counters keyed by phone | `phone` primary key, `@@index([windowStart])` |
+
 ## Model Details
 
 ### Tenant
@@ -75,6 +82,18 @@ paid timestamp, and audit timestamps.
 `AuditLog` stores action history with optional actor and entity references. `metadata` is stored as a
 string so callers can serialize structured context when needed.
 
+### OtpCode
+
+`OtpCode` stores the hashed one-time code, expiry timestamp, failed-attempt count, and consumed flag
+for a normalized phone number. Keeping consumed rows until expiry lets verification return an
+explicit already-used response across server instances.
+
+### OtpRateLimit
+
+`OtpRateLimit` stores the current OTP request window, request count, and last-send timestamp for a
+normalized phone number. This keeps resend cooldowns and rate limits consistent across server
+instances.
+
 ## Running Migrations
 
 The schema uses SQLite with `url = "file:./dev.db"`, so local migrations create
@@ -105,6 +124,7 @@ checked-in migration:
 | Migration | Description |
 |-----------|-------------|
 | `20260611112538_init` | Creates the initial SQLite schema for tenants, users, services, staff, business hours, clients, bookings, payments, and audit logs. It also creates all unique constraints and tenant indexes declared in `schema.prisma`. |
+| `20260729112000_add_otp_persistent_store` | Adds shared OTP code and OTP rate-limit tables used by phone authentication. |
 
 [`prisma/migrations/migration_lock.toml`](../prisma/migrations/migration_lock.toml) records the
 database provider as `sqlite`. Do not edit generated migration files by hand after they have been

--- a/prisma/migrations/20260729112000_add_otp_persistent_store/migration.sql
+++ b/prisma/migrations/20260729112000_add_otp_persistent_store/migration.sql
@@ -1,0 +1,24 @@
+-- Persist OTP and rate-limit state outside of a single application process.
+
+CREATE TABLE "OtpCode" (
+    "phone" TEXT NOT NULL PRIMARY KEY,
+    "hash" TEXT NOT NULL,
+    "expiresAt" DATETIME NOT NULL,
+    "attempts" INTEGER NOT NULL DEFAULT 0,
+    "consumed" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL
+);
+
+CREATE TABLE "OtpRateLimit" (
+    "phone" TEXT NOT NULL PRIMARY KEY,
+    "windowStart" DATETIME NOT NULL,
+    "count" INTEGER NOT NULL DEFAULT 0,
+    "lastSentAt" DATETIME NOT NULL,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL
+);
+
+CREATE INDEX "OtpCode_expiresAt_idx" ON "OtpCode"("expiresAt");
+
+CREATE INDEX "OtpRateLimit_windowStart_idx" ON "OtpRateLimit"("windowStart");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -168,3 +168,25 @@ model AuditLog {
   @@index([tenantId, entityType, entityId])
 }
 
+model OtpCode {
+  phone     String   @id
+  hash      String
+  expiresAt DateTime
+  attempts  Int      @default(0)
+  consumed  Boolean  @default(false)
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([expiresAt])
+}
+
+model OtpRateLimit {
+  phone       String   @id
+  windowStart DateTime
+  count       Int      @default(0)
+  lastSentAt  DateTime
+  createdAt   DateTime @default(now())
+  updatedAt   DateTime @updatedAt
+
+  @@index([windowStart])
+}


### PR DESCRIPTION
<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
PR #80 addressed issue #79, but verification returned a verdict of **CONCERNS** due to missing or insufficient test coverage and production robustness. This follow-up issue addresses the remaining gaps by improving test structure, enforcing secure configuration, and replacing unreliable in-memory state with persistent storage.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#80](https://github.com/iamkayleb/bukay/issues/80)
- [#79](https://github.com/iamkayleb/bukay/issues/79)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [x] Add tests to explicitly verify OTP expiration rejection by simulating expired OTPs and asserting rejection.
- [x] Add tests to explicitly verify rate-limit enforcement and rejection by simulating multiple OTP requests and asserting rate-limit blocks.
- [x] Add tests for session expiry and tampering by simulating expired session cookies and modified cookies, and asserting rejection.
- [x] Replace in-memory Maps for OTP and rate-limit state with a shared persistent store (e.g., Redis), ensuring state survives server restarts and works across multiple instances.
- [x] Update OTP secret handling to enforce environment variable usage in production, rejecting startup if OTP_SECRET is not set.

#### Acceptance criteria
- [x] Submitting an expired OTP via the OTP verification endpoint returns a 400 or 401 error, and the response contains an explicit 'OTP expired' message.
- [x] Submitting a used OTP via the OTP verification endpoint returns a 400 or 401 error, and the response contains an explicit 'OTP already used' message.
- [x] Requesting OTPs more than the configured rate limit within the rate-limit window results in a 429 error, and the response contains a 'rate limit exceeded' message.
- [x] Session cookies that are expired or have been tampered with are rejected by the authentication system, returning a 401 error and an explicit 'session expired' or 'session invalid' message.
- [x] OTP and rate-limit state are stored in a shared persistent store (e.g., Redis), and state persists across server restarts and is accessible from multiple server instances.
- [x] In production mode, the application fails to start with an explicit error if the OTP_SECRET environment variable is not set.

<!-- auto-status-summary:end -->

<details>

<summary>Full Issue Text</summary>



## Why
PR #80 addressed issue #79, but verification returned a verdict of **CONCERNS** due to missing or insufficient test coverage and production robustness. This follow-up issue addresses the remaining gaps by improving test structure, enforcing secure configuration, and replacing unreliable in-memory state with persistent storage.

## Scope
_Not provided._

## Non-Goals
_Not provided._

## Tasks
- [x] Add tests to explicitly verify OTP expiration rejection by simulating expired OTPs and asserting rejection.
- [x] Add tests to explicitly verify rate-limit enforcement and rejection by simulating multiple OTP requests and asserting rate-limit blocks.
- [ ] Add tests for session expiry and tampering by simulating expired session cookies and modified cookies, and asserting rejection.
- [ ] Replace in-memory Maps for OTP and rate-limit state with a shared persistent store (e.g., Redis), ensuring state survives server restarts and works across multiple instances.
- [ ] Update OTP secret handling to enforce environment variable usage in production, rejecting startup if OTP_SECRET is not set.

## Acceptance Criteria
- [x] Submitting an expired OTP via the OTP verification endpoint returns a 400 or 401 error, and the response contains an explicit 'OTP expired' message.
- [ ] Submitting a used OTP via the OTP verification endpoint returns a 400 or 401 error, and the response contains an explicit 'OTP already used' message.
- [x] Requesting OTPs more than the configured rate limit within the rate-limit window results in a 429 error, and the response contains a 'rate limit exceeded' message.
- [ ] Session cookies that are expired or have been tampered with are rejected by the authentication system, returning a 401 error and an explicit 'session expired' or 'session invalid' message.
- [ ] OTP and rate-limit state are stored in a shared persistent store (e.g., Redis), and state persists across server restarts and is accessible from multiple server instances.
- [ ] In production mode, the application fails to start with an explicit error if the OTP_SECRET environment variable is not set.

## Implementation Notes
- Add new or update existing test cases in `test/otp.test.js` and `test/session.test.js` to cover OTP expiration, used OTPs, rate-limit enforcement, session expiry, and tampering scenarios.
- Refactor `src/otp.js` and `src/rateLimit.js` to use Redis (or equivalent) for state storage, replacing in-memory Maps. Ensure state persists across server restarts and is accessible from multiple instances.
- Update `src/config.js` and `src/otp.js` to enforce that OTP_SECRET must be set via environment variable in production; fail startup with a clear error if not set.
- Ensure error responses are explicit and match acceptance criteria (e.g., 'OTP expired', 'OTP already used', 'rate limit exceeded', 'session expired', 'session invalid').
- Integration tests should simulate server restarts to verify persistence.
- Deferred: Clarify whether durable user/account creation is required for 'sign up', or if phone verification alone suffices for the current scope.

<details>
<summary>Original Issue</summary>

```text
<!-- follow-up-depth: 1 -->
<!-- base-branch: eval/codex -->
## Why
PR #80 addressed issue #79, but verification returned a verdict of **CONCERNS** due to missing or insufficient test coverage and production robustness. This follow-up issue addresses the remaining gaps by improving test structure, enforcing secure configuration, and replacing unreliable in-memory state with persistent storage.

## Source
- Original PR: #80
- Parent issue: #79

## Tasks
- [ ] Add tests to explicitly verify OTP expiration rejection by simulating expired OTPs and asserting rejection.
- [ ] Add tests to explicitly verify rate-limit enforcement and rejection by simulating multiple OTP requests and asserting rate-limit blocks.
- [ ] Add tests for session expiry and tampering by simulating expired session cookies and modified cookies, and asserting rejection.
- [ ] Replace in-memory Maps for OTP and rate-limit state with a shared persistent store (e.g., Redis), ensuring state survives server restarts and works across multiple instances.
- [ ] Update OTP secret handling to enforce environment variable usage in production, rejecting startup if OTP_SECRET is not set.

## Acceptance Criteria
- [ ] Submitting an expired OTP via the OTP verification endpoint returns a 400 or 401 error, and the response contains an explicit 'OTP expired' message.
- [ ] Submitting a used OTP via the OTP verification endpoint returns a 400 or 401 error, and the response contains an explicit 'OTP already used' message.
- [ ] Requesting OTPs more than the configured rate limit within the rate-limit window results in a 429 error, and the response contains a 'rate limit exceeded' message.
- [ ] Session cookies that are expired or have been tampered with are rejected by the authentication system, returning a 401 error and an explicit 'session expired' or 'session invalid' message.
- [ ] OTP and rate-limit state are stored in a shared persistent store (e.g., Redis), and state persists across server restarts and is accessible from multiple server instances.
- [ ] In production mode, the application fails to start with an explicit error if the OTP_SECRET environment variable is not set.

## Implementation Notes
- Add new or update existing test cases in `test/otp.test.js` and `test/session.test.js` to cover OTP expiration, used OTPs, rate-limit enforcement, session expiry, and tampering scenarios.
- Refactor `src/otp.js` and `src/rateLimit.js` to use Redis (or equivalent) for state storage, replacing in-memory Maps. Ensure state persists across server restarts and is accessible from multiple instances.
- Update `src/config.js` and `src/otp.js` to enforce that OTP_SECRET must be set via environment variable in production; fail startup with a clear error if not set.
- Ensure error responses are explicit and match acceptance criteria (e.g., 'OTP expired', 'OTP already used', 'rate limit exceeded', 'session expired', 'session invalid').
- Integration tests should simulate server restarts to verify persistence.
- Deferred: Clarify whether durable user/account creation is required for 'sign up', or if phone verification alone suffices for the current scope.

## Notes
<details>
<summary>Advisory items (non-blocking)</summary>

- Rate limit is keyed by normalized phone only; it does not include IP, so a determined attacker rotating phones could still abuse the endpoint. Brute-force per-phone is mitigated by MAX_VERIFY_ATTEMPTS=5 plus per-phone request cap.
- it does not include IP, so a determined attacker rotating phones could still abuse the endpoint. Brute-force per-phone is mitigated by MAX_VERIFY_ATTEMPTS=5 plus per-phone request cap.

</details>
```
</details>



</details>

—
PR created automatically to engage Codex.

<!-- pr-preamble:start -->
> **Source:** Issue #168

<!-- pr-preamble:end -->