### PR TITLE
Codex bootstrap for #170

### DIFF
--- a/__tests__/app/api/bookings/route.test.ts
+++ b/__tests__/app/api/bookings/route.test.ts
@@ -24,14 +24,25 @@ type BusinessHourRow = {
   isClosed: boolean;
 };
 
+type ServiceRow = {
+  id: string;
+  tenantId: string;
+  durationMinutes: number;
+  active: boolean;
+};
+
 type NextRequestInit = NonNullable<ConstructorParameters<typeof NextRequest>[1]>;
+type CreateBookingData = Omit<BookingRow, "id" | "createdAt" | "updatedAt">;
 
 const state = vi.hoisted(() => ({
   bookings: [] as BookingRow[],
   businessHours: [] as BusinessHourRow[],
+  services: [] as ServiceRow[],
   findBookingFirst: vi.fn(),
   findBookingMany: vi.fn(),
+  createBooking: vi.fn(),
   updateBooking: vi.fn(),
+  findServiceFirst: vi.fn(),
   findBusinessHourFirst: vi.fn(),
   findBlackoutDateFirst: vi.fn(),
   tenantFindUnique: vi.fn(),
@@ -42,7 +53,11 @@ vi.mock("@/app/db/prisma", () => ({
     booking: {
       findFirst: state.findBookingFirst,
       findMany: state.findBookingMany,
+      create: state.createBooking,
       update: state.updateBooking,
+    },
+    service: {
+      findFirst: state.findServiceFirst,
     },
     businessHour: {
       findFirst: state.findBusinessHourFirst,
@@ -56,6 +71,7 @@ vi.mock("@/app/db/prisma", () => ({
   },
 }));
 
+import { POST } from "@/app/api/bookings/route";
 import { PATCH } from "@/app/api/bookings/[id]/route";
 
 function booking(overrides: Partial<BookingRow> = {}): BookingRow {
@@ -75,6 +91,16 @@ function booking(overrides: Partial<BookingRow> = {}): BookingRow {
   };
 }
 
+function service(overrides: Partial<ServiceRow> = {}): ServiceRow {
+  return {
+    id: "service-1",
+    tenantId: "tenant-1",
+    durationMinutes: 60,
+    active: true,
+    ...overrides,
+  };
+}
+
 function request(path: string, body: unknown, init: NextRequestInit = {}) {
   return new NextRequest(`http://app.test${path}`, {
     ...init,
@@ -90,6 +116,7 @@ function request(path: string, body: unknown, init: NextRequestInit = {}) {
 
 beforeEach(() => {
   state.bookings = [booking()];
+  state.services = [service()];
   state.businessHours = [
     {
       id: "hours-1",
@@ -103,7 +130,9 @@ beforeEach(() => {
 
   state.findBookingFirst.mockReset();
   state.findBookingMany.mockReset();
+  state.createBooking.mockReset();
   state.updateBooking.mockReset();
+  state.findServiceFirst.mockReset();
   state.findBusinessHourFirst.mockReset();
   state.findBlackoutDateFirst.mockReset();
   state.tenantFindUnique.mockReset();
@@ -136,6 +165,14 @@ beforeEach(() => {
         )
         .slice(0, args.take)
   );
+  state.createBooking.mockImplementation(async (args: { data: CreateBookingData }) => {
+    const row = booking({
+      id: `booking-${state.bookings.length + 1}`,
+      ...args.data,
+    });
+    state.bookings.push(row);
+    return row;
+  });
   state.updateBooking.mockImplementation(
     async (args: { where: { id: string }; data: Partial<BookingRow> }) => {
       const index = state.bookings.findIndex((row) => row.id === args.where.id);
@@ -158,7 +195,77 @@ beforeEach(() => {
         (row) => row.tenantId === args.where.tenantId && row.dayOfWeek === args.where.dayOfWeek
       ) ?? null
   );
+  state.findServiceFirst.mockImplementation(
+    async (args: { where: { tenantId: string; id: string; active?: boolean } }) =>
+      state.services.find(
+        (row) =>
+          row.tenantId === args.where.tenantId &&
+          row.id === args.where.id &&
+          (args.where.active === undefined || row.active === args.where.active)
+      ) ?? null
+  );
   state.findBlackoutDateFirst.mockResolvedValue(null);
+});
+
+describe("POST /api/bookings", () => {
+  it("creates a booking only after finding an active tenant service", async () => {
+    state.bookings = [];
+
+    const res = await POST(
+      request("/api/bookings", {
+        clientId: "client-1",
+        serviceId: "service-1",
+        staffId: "staff-1",
+        startsAt: "2026-07-27T10:00:00.000Z",
+      })
+    );
+
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.booking).toMatchObject({
+      tenantId: "tenant-1",
+      clientId: "client-1",
+      serviceId: "service-1",
+      status: "pending",
+    });
+    expect(body.booking.endsAt).toBe("2026-07-27T11:00:00.000Z");
+    expect(state.findServiceFirst).toHaveBeenCalledWith({
+      where: { tenantId: "tenant-1", id: "service-1", active: true },
+    });
+    expect(state.createBooking).toHaveBeenCalledWith({
+      data: {
+        tenantId: "tenant-1",
+        clientId: "client-1",
+        serviceId: "service-1",
+        staffId: "staff-1",
+        startsAt: new Date("2026-07-27T10:00:00.000Z"),
+        endsAt: new Date("2026-07-27T11:00:00.000Z"),
+        status: "pending",
+        notes: undefined,
+      },
+    });
+  });
+
+  it("rejects booking requests for archived services", async () => {
+    state.services = [service({ active: false })];
+
+    const res = await POST(
+      request("/api/bookings", {
+        clientId: "client-1",
+        serviceId: "service-1",
+        staffId: "staff-1",
+        startsAt: "2026-07-27T10:00:00.000Z",
+      })
+    );
+
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toBe("SERVICE_NOT_FOUND");
+    expect(state.findServiceFirst).toHaveBeenCalledWith({
+      where: { tenantId: "tenant-1", id: "service-1", active: true },
+    });
+    expect(state.createBooking).not.toHaveBeenCalled();
+  });
 });
 
 describe("PATCH /api/bookings/:id", () => {

--- a/__tests__/app/api/services/route.test.ts
+++ b/__tests__/app/api/services/route.test.ts
@@ -89,8 +89,13 @@ beforeEach(() => {
   state.update.mockReset();
   state.tenantFindUnique.mockReset();
 
-  state.findMany.mockImplementation(async (args: { where: { tenantId: string } }) =>
-    state.services.filter((row) => row.tenantId === args.where.tenantId)
+  state.findMany.mockImplementation(
+    async (args: { where: { tenantId: string; active?: boolean } }) =>
+      state.services.filter(
+        (row) =>
+          row.tenantId === args.where.tenantId &&
+          (args.where.active === undefined || row.active === args.where.active)
+      )
   );
   state.create.mockImplementation(async (args: { data: CreateServiceData }) => {
     if (
@@ -161,7 +166,30 @@ describe("/api/services", () => {
       priceKobo: 750000,
     });
     expect(state.findMany).toHaveBeenCalledWith({
-      where: { tenantId: "tenant-1" },
+      where: { tenantId: "tenant-1", active: true },
+      orderBy: [{ active: "desc" }, { name: "asc" }],
+    });
+  });
+
+  it("does not expose archived services in the public list", async () => {
+    state.services.push(
+      service({ id: "service-3", tenantId: "tenant-1", name: "Archived", active: false })
+    );
+
+    const res = await GET(request("/api/services"));
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.services).toHaveLength(1);
+    expect(body.services).toEqual([
+      expect.objectContaining({
+        id: "service-1",
+        active: true,
+      }),
+    ]);
+    expect(body.services.some((service: ServiceRow) => service.id === "service-3")).toBe(false);
+    expect(state.findMany).toHaveBeenCalledWith({
+      where: { tenantId: "tenant-1", active: true },
       orderBy: [{ active: "desc" }, { name: "asc" }],
     });
   });
@@ -376,7 +404,7 @@ describe("/api/services", () => {
       select: { id: true },
     });
     expect(state.findMany).toHaveBeenCalledWith({
-      where: { tenantId: "tenant-from-slug" },
+      where: { tenantId: "tenant-from-slug", active: true },
       orderBy: [{ active: "desc" }, { name: "asc" }],
     });
   });

--- a/__tests__/app/booking/BookingServiceList.test.tsx
+++ b/__tests__/app/booking/BookingServiceList.test.tsx
@@ -1,0 +1,37 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+
+import { BookingServiceList, getActiveBookingServices } from "@/app/booking/BookingServiceList";
+
+const services = [
+  {
+    id: "service-1",
+    name: "Haircut",
+    durationMinutes: 45,
+    priceKobo: 750000,
+    active: true,
+  },
+  {
+    id: "service-2",
+    name: "Archived massage",
+    durationMinutes: 60,
+    priceKobo: 1200000,
+    active: false,
+  },
+];
+
+describe("BookingServiceList", () => {
+  it("returns only active services for booking selection", () => {
+    expect(getActiveBookingServices(services)).toEqual([services[0]]);
+  });
+
+  it("does not render archived services as selectable options", () => {
+    const html = renderToStaticMarkup(
+      <BookingServiceList services={services} selectedServiceId={null} onSelect={() => {}} />
+    );
+
+    expect(html).toContain("Haircut");
+    expect(html).not.toContain("Archived massage");
+    expect(html).not.toContain("service-2");
+  });
+});

--- a/agents/codex-170.md
+++ b/agents/codex-170.md
@@ -1,0 +1,1 @@
+<!-- bootstrap for codex on issue #170 -->

--- a/api/bookings.ts
+++ b/api/bookings.ts
@@ -33,6 +33,24 @@ type BookingUpdateData = {
   notes?: string | null;
 };
 
+type BookingCreateData = {
+  tenantId: string;
+  clientId: string;
+  serviceId: string;
+  staffId: string | null;
+  startsAt: Date;
+  endsAt: Date;
+  status: string;
+  notes?: string | null;
+};
+
+type BookingServiceRecord = {
+  id: string;
+  tenantId: string;
+  durationMinutes: number;
+  active: boolean;
+};
+
 const bookingDateField = z.preprocess(
   (value) => {
     if (typeof value !== "string") {
@@ -59,10 +77,25 @@ const updateBookingSchema = z
     path: ["_form"],
   });
 
+const createBookingSchema = z
+  .object({
+    clientId: z.string().trim().min(1, "Client is required"),
+    serviceId: z.string().trim().min(1, "Service is required"),
+    staffId: z.string().trim().min(1, "Staff is required").nullable().optional(),
+    startsAt: bookingDateField,
+    notes: z.string().nullable().optional(),
+  })
+  .strict();
+
 const bookingDelegate = prisma.booking as unknown as {
   findFirst(args: unknown): Promise<BookingRecord | null>;
   findMany(args: unknown): Promise<BookingRecord[]>;
+  create(args: unknown): Promise<BookingRecord>;
   update(args: unknown): Promise<BookingRecord>;
+};
+
+const serviceDelegate = prisma.service as unknown as {
+  findFirst(args: unknown): Promise<BookingServiceRecord | null>;
 };
 
 const businessHourDelegate = prisma.businessHour as unknown as {
@@ -123,6 +156,76 @@ function buildValidationStore(): BookingValidationStore {
       return overlappingBookings[0] ?? null;
     },
   };
+}
+
+export async function POST(req: NextRequest) {
+  const body = await readJson(req);
+  if (body instanceof NextResponse) {
+    return body;
+  }
+
+  const parsed = createBookingSchema.safeParse(body);
+  if (!parsed.success) {
+    return validationError(parsed.error);
+  }
+
+  return runForTenant(req, async (tenantId) => {
+    const service = await serviceDelegate.findFirst({
+      where: {
+        tenantId,
+        id: parsed.data.serviceId,
+        active: true,
+      },
+    });
+
+    if (!service) {
+      return jsonError("SERVICE_NOT_FOUND", 404);
+    }
+
+    const staffId = parsed.data.staffId ?? null;
+    const startsAt = parsed.data.startsAt;
+    const endsAt = new Date(startsAt.getTime() + service.durationMinutes * 60_000);
+    const pendingBooking = {
+      id: "new-booking",
+      tenantId,
+      staffId,
+      startsAt,
+      endsAt,
+    };
+    const validationIssue = await validateBookingInterval(buildValidationStore(), pendingBooking, {
+      startsAt,
+      endsAt,
+      staffId,
+    });
+
+    if (validationIssue) {
+      return NextResponse.json(
+        {
+          ok: false,
+          error: validationIssue.code,
+          message: validationIssue.message,
+        },
+        { status: validationIssue.status }
+      );
+    }
+
+    const data: BookingCreateData = {
+      tenantId,
+      clientId: parsed.data.clientId,
+      serviceId: service.id,
+      staffId,
+      startsAt,
+      endsAt,
+      status: "pending",
+      notes: parsed.data.notes,
+    };
+
+    const booking = await bookingDelegate.create({
+      data,
+    });
+
+    return NextResponse.json({ ok: true, booking: serializeBooking(booking) }, { status: 201 });
+  });
 }
 
 export async function PATCH(req: NextRequest, { params }: RouteContext) {

--- a/app/api/bookings/route.ts
+++ b/app/api/bookings/route.ts
@@ -1,0 +1,1 @@
+export { dynamic, POST } from "@/api/bookings";

--- a/app/api/services/route.ts
+++ b/app/api/services/route.ts
@@ -22,7 +22,7 @@ const serviceDelegate = prisma.service as unknown as {
 export async function GET(req: NextRequest) {
   return runForTenant(req, async (tenantId) => {
     const services = await serviceDelegate.findMany({
-      where: { tenantId },
+      where: { tenantId, active: true },
       orderBy: [{ active: "desc" }, { name: "asc" }],
     });
 

--- a/app/booking/BookingServiceList.tsx
+++ b/app/booking/BookingServiceList.tsx
@@ -1,0 +1,71 @@
+"use client";
+
+type BookingService = {
+  id: string;
+  name: string;
+  durationMinutes: number;
+  priceKobo: number;
+  active: boolean;
+};
+
+type BookingServiceListProps = {
+  services: BookingService[];
+  selectedServiceId?: string | null;
+  onSelect(serviceId: string): void;
+};
+
+export function getActiveBookingServices(services: BookingService[]) {
+  return services.filter((service) => service.active);
+}
+
+function formatNaira(priceKobo: number) {
+  return new Intl.NumberFormat("en-NG", {
+    style: "currency",
+    currency: "NGN",
+    maximumFractionDigits: 0,
+  }).format(priceKobo / 100);
+}
+
+export function BookingServiceList({
+  services,
+  selectedServiceId,
+  onSelect,
+}: BookingServiceListProps) {
+  const activeServices = getActiveBookingServices(services);
+
+  if (activeServices.length === 0) {
+    return <p className="text-sm text-slate-400">No services are available for booking.</p>;
+  }
+
+  return (
+    <fieldset className="space-y-3">
+      <legend className="text-sm font-semibold text-slate-100">Choose a service</legend>
+      <ul className="grid gap-3 sm:grid-cols-2">
+        {activeServices.map((service) => {
+          const isSelected = selectedServiceId === service.id;
+
+          return (
+            <li key={service.id}>
+              <button
+                aria-pressed={isSelected}
+                className={[
+                  "w-full rounded-md border px-4 py-3 text-left text-sm transition",
+                  isSelected
+                    ? "border-emerald-400 bg-emerald-950/40 text-white"
+                    : "border-slate-800 bg-slate-900 text-slate-200 hover:border-emerald-400",
+                ].join(" ")}
+                type="button"
+                onClick={() => onSelect(service.id)}
+              >
+                <span className="block font-medium">{service.name}</span>
+                <span className="mt-1 block text-xs text-slate-400">
+                  {service.durationMinutes} min - {formatNaira(service.priceKobo)}
+                </span>
+              </button>
+            </li>
+          );
+        })}
+      </ul>
+    </fieldset>
+  );
+}


### PR DESCRIPTION
<!-- auto-status-summary:start -->
## Automated Status Summary
#### Scope
PR #87 addressed issue #86 but verification identified concerns (verdict: **CONCERNS**). This follow-up addresses the remaining gaps by enforcing filtering for active services in both API and UI, and adding tests to prevent archived services from being exposed or bookable.

<!-- Updated WORKFLOW_OUTPUTS.md context:start -->
## Context for Agent

### Related Issues/PRs
- [#87](https://github.com/iamkayleb/bukay/issues/87)
- [#86](https://github.com/iamkayleb/bukay/issues/86)
<!-- Updated WORKFLOW_OUTPUTS.md context:end -->

#### Tasks
- [x] Update the public GET /api/services endpoint to filter and return only services where active=true.
  - [x] Define scope for: Update the public GET /api/services endpoint to filter (verify: confirm completion in repo)
  - [x] Implement focused slice for: Update the public GET /api/services endpoint to filter (verify: confirm completion in repo)
  - [x] Validate focused slice for: Update the public GET /api/services endpoint to filter (verify: confirm completion in repo) return only services where active=true. (verify: confirm completion in repo)
- [x] Update booking UI components and booking-related API endpoints to display/select only services with active=true.
  - [x] Update booking UI components (verify: confirm completion in repo)
  - [x] Define scope for: booking-related API endpoints to display/select only services with active=true. (verify: confirm completion in repo)
  - [x] Implement focused slice for: booking-related API endpoints to display/select only services with active=true. (verify: confirm completion in repo)
  - [x] Validate focused slice for: booking-related API endpoints to display/select only services with active=true. (verify: confirm completion in repo)
- [x] Add or update automated tests to verify that booking surfaces and public service list endpoints do not expose archived services.
  - [x] Add or update automated tests to verify that booking surfaces
  - [x] Define scope for: public service list endpoints do not expose archived services. (verify: confirm completion in repo)
  - [x] Implement focused slice for: public service list endpoints do not expose archived services. (verify: confirm completion in repo)
  - [x] Validate focused slice for: public service list endpoints do not expose archived services. (verify: confirm completion in repo)

#### Acceptance criteria
- [x] The public GET /api/services endpoint returns only services where active=true; services with active=false are not included in the response.
- [x] Booking UI components (e.g., BookingServiceList.tsx) display only services with active=true; archived (active=false) services are not shown or selectable.
- [x] Booking-related API endpoints (e.g., POST /api/booking) reject booking requests for services where active=false, returning a 400 or 404 error.
- [x] Automated tests in tests/services.test.ts and tests/booking.test.ts verify that archived (active=false) services are not exposed on booking surfaces or endpoints, and that regressions are detected.

<!-- auto-status-summary:end -->

<details>

<summary>Full Issue Text</summary>



## Why

PR #87 addressed issue #86 but verification identified concerns (verdict: **CONCERNS**). This follow-up addresses the remaining gaps by enforcing filtering for active services in both API and UI, and adding tests to prevent archived services from being exposed or bookable.

## Scope

Enforce filtering for active services (`active=true`) in both API and UI.
Add tests to ensure archived services are not exposed or bookable.

## Non-Goals

Do not address deferred items (tenantId exposure, unrelated test errors).
Owner authentication/authorization enforcement is not included.

## Tasks

- [ ] Update the public GET /api/services endpoint to filter and return only services where active=true.
  - [ ] Define scope for: Update the public GET /api/services endpoint to filter (verify: confirm completion in repo)
  - [ ] Implement focused slice for: Update the public GET /api/services endpoint to filter (verify: confirm completion in repo)
  - [ ] Validate focused slice for: Update the public GET /api/services endpoint to filter (verify: confirm completion in repo)
  - [x] return only services where active=true. (verify: confirm completion in repo)
- [ ] Update booking UI components and booking-related API endpoints to display/select only services with active=true.
  - [ ] Update booking UI components (verify: confirm completion in repo)
  - [ ] Define scope for: booking-related API endpoints to display/select only services with active=true. (verify: confirm completion in repo)
  - [ ] Implement focused slice for: booking-related API endpoints to display/select only services with active=true. (verify: confirm completion in repo)
  - [ ] Validate focused slice for: booking-related API endpoints to display/select only services with active=true. (verify: confirm completion in repo)
- [ ] Add or update automated tests to verify that booking surfaces and public service list endpoints do not expose archived services.
  - [ ] Add or update automated tests to verify that booking surfaces
  - [ ] Define scope for: public service list endpoints do not expose archived services. (verify: confirm completion in repo)
  - [ ] Implement focused slice for: public service list endpoints do not expose archived services. (verify: confirm completion in repo)
  - [ ] Validate focused slice for: public service list endpoints do not expose archived services. (verify: confirm completion in repo)

## Acceptance Criteria

- [ ] The public GET /api/services endpoint returns only services where active=true; services with active=false are not included in the response.
- [ ] Booking UI components (e.g., BookingServiceList.tsx) display only services with active=true; archived (active=false) services are not shown or selectable.
- [ ] Booking-related API endpoints (e.g., POST /api/booking) reject booking requests for services where active=false, returning a 400 or 404 error.
- [ ] Automated tests in tests/services.test.ts and tests/booking.test.ts verify that archived (active=false) services are not exposed on booking surfaces or endpoints, and that regressions are detected.

## Implementation Notes

In `api/services.ts` and `serviceModel.ts`, ensure the GET endpoint explicitly filters for `active=true` when returning services.
In `components/BookingServiceList.tsx` and `api/booking.ts`, update logic to ensure only active services are displayed and selectable, and that booking requests for inactive services are rejected.
Add or update tests in `tests/services.test.ts` and `tests/booking.test.ts` to cover scenarios where both active and inactive services exist, verifying that only active services are exposed and bookable.
Do not address deferred items (tenantId exposure, unrelated test errors) in this issue.

<details>
<summary>Original Issue</summary>

```text
<!-- follow-up-depth: 1 -->
<!-- base-branch: eval/codex -->
## Why
PR #87 addressed issue #86 but verification identified concerns (verdict: **CONCERNS**). This follow-up addresses the remaining gaps by enforcing filtering for active services in both API and UI, and adding tests to prevent archived services from being exposed or bookable.

## Source
- Original PR: #87
- Parent issue: #86

## Tasks
- [ ] Update the public GET /api/services endpoint to filter and return only services where active=true.
- [ ] Update booking UI components and booking-related API endpoints to display/select only services with active=true.
- [ ] Add or update automated tests to verify that booking surfaces and public service list endpoints do not expose archived services.

## Acceptance Criteria
- [ ] The public GET /api/services endpoint returns only services where active=true; services with active=false are not included in the response.
- [ ] Booking UI components (e.g., BookingServiceList.tsx) display only services with active=true; archived (active=false) services are not shown or selectable.
- [ ] Booking-related API endpoints (e.g., POST /api/booking) reject booking requests for services where active=false, returning a 400 or 404 error.
- [ ] Automated tests in tests/services.test.ts and tests/booking.test.ts verify that archived (active=false) services are not exposed on booking surfaces or endpoints, and that regressions are detected.

## Implementation Notes
- In `api/services.ts` and `serviceModel.ts`, ensure the GET endpoint explicitly filters for `active=true` when returning services.
- In `components/BookingServiceList.tsx` and `api/booking.ts`, update logic to ensure only active services are displayed and selectable, and that booking requests for inactive services are rejected.
- Add or update tests in `tests/services.test.ts` and `tests/booking.test.ts` to cover scenarios where both active and inactive services exist, verifying that only active services are exposed and bookable.
- Do not address deferred items (tenantId exposure, unrelated test errors) in this issue.

## Notes
<details>
<summary>Advisory items (non-blocking)</summary>

- The services API does not enforce owner authentication or authorization. It resolves tenant scope from request headers/host, but any caller able to reach the endpoint could create, update, archive, or delete tenant services if they can supply or infer tenant context.
- The services UI page (/app/services) is exposed without authentication/authorization checks in the diff - any visitor with a tenant context could manage services. Owner-only enforcement is not visible.

</details>

<details>
<summary>Background (previous attempt context)</summary>

- The previous PR relied on booking surfaces already filtering for active services, but did not enforce this in the API or UI code.
- This assumption led to archived services being exposed via the public API, which does not meet the acceptance criteria.
- Explicitly filter for active=true in all booking-related endpoints and UI components, and add tests to verify this behavior.

</details>
```
</details>



</details>

—
PR created automatically to engage Codex.

<!-- pr-preamble:start -->
> **Source:** Issue #170

<!-- pr-preamble:end -->